### PR TITLE
Add GitHub Pull Request Template for Consistency

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+## Description of change
+
+<!-- Description of the changes made -->
+
+## Link to Jira Ticket
+
+- [SDS-](https://dsdmoj.atlassian.net/browse/SDS-{ticketNumber})
+
+## Screenshots or test evidence if applicable
+
+<!-- Any evidence of change working -->


### PR DESCRIPTION
This commit introduces a standard PR template located in the .github folder. The template includes sections for the Description, Jira ticke, screenshots. This addition aims to streamline PR submissions, ensuring that all contributions are well-documented and adhere to the project's guidelines.