### PR TITLE
SDS-22 Ading dynamo db configuration

### DIFF
--- a/.env
+++ b/.env
@@ -2,3 +2,5 @@ AWS_REGION = 'us-east-1'
 AWS_ENDPOINT_URL = 'http://localhost:4566'
 CLAMD_HOST = 'localhost'
 CLAMD_PORT = '3310'
+IS_LOCAL=true
+PYTHONPATH=src

--- a/Pipfile
+++ b/Pipfile
@@ -7,8 +7,13 @@ name = "pypi"
 fastapi = "*"
 uvicorn = {extras = ["standard"], version = "*"}
 clamd = "*"
+boto3 = "*"
+python-multipart = "*"
+httpx = "*"
 
 [dev-packages]
+pytest = "*"
+pytest-asyncio = "*"
 
 [requires]
 python_version = "3.9"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "fd57a22b4b4eca27def3667a32c1e1432404955c1b0725b6930b81e303e26ded"
+            "sha256": "752af1a2409423c944495db26eb0f414836c90c6283e8a5529bc3a00a450b1af"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -27,12 +27,36 @@
         },
         "anyio": {
             "hashes": [
-                "sha256:745843b39e829e108e518c489b31dc757de7d2131d53fac32bd8df268227bfee",
-                "sha256:e1875bb4b4e2de1669f4bc7869b6d3f54231cdced71605e6e64c9be77e3be50f"
+                "sha256:048e05d0f6caeed70d731f3db756d35dcc1f35747c8c403364a8332c630441b8",
+                "sha256:f75253795a87df48568485fd18cdd2a3fa5c4f7c5be8e5e36637733fce06fed6"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==4.2.0"
-
+            "version": "==4.3.0"
+        },
+        "boto3": {
+            "hashes": [
+                "sha256:66303b5f26d92afb72656ff490b22ea72dfff8bf1a29e4a0c5d5f11ec56245dd",
+                "sha256:898ad2123b18cae8efd85adc56ac2d1925be54592aebc237020d4f16e9a9e7a9"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.8'",
+            "version": "==1.34.52"
+        },
+        "botocore": {
+            "hashes": [
+                "sha256:05567d8aba344826060481ea309555432c96f0febe22bee7cf5a3b6d3a03cec8",
+                "sha256:187da93aec3f2e87d8a31eced16fa2cb9c71fe2d69b0a797f9f7a9220f5bf7ae"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==1.34.52"
+        },
+        "certifi": {
+            "hashes": [
+                "sha256:0569859f95fc761b18b45ef421b1290a0f65f147e92a1e5eb3e635f9a5e4e66f",
+                "sha256:dc383c07b76109f368f6106eee2b593b04a011ea4d55f652c6ca24a754d1cdd1"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==2024.2.2"
         },
         "clamd": {
             "hashes": [
@@ -41,7 +65,6 @@
             ],
             "index": "pypi",
             "version": "==1.0.2"
-
         },
         "click": {
             "hashes": [
@@ -61,12 +84,12 @@
         },
         "fastapi": {
             "hashes": [
-                "sha256:8c77515984cd8e8cfeb58364f8cc7a28f0692088475e2614f7bf03275eba9093",
-                "sha256:b978095b9ee01a5cf49b19f4bc1ac9b8ca83aa076e770ef8fd9af09a2b88d191"
+                "sha256:266775f0dcc95af9d3ef39bad55cff525329a931d5fd51930aadd4f428bf7ff3",
+                "sha256:87a1f6fb632a218222c5984be540055346a8f5d8a68e8f6fb647b1dc9934de4b"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.8'",
-            "version": "==0.109.0"
+            "version": "==0.110.0"
         },
         "h11": {
             "hashes": [
@@ -75,6 +98,14 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==0.14.0"
+        },
+        "httpcore": {
+            "hashes": [
+                "sha256:ac418c1db41bade2ad53ae2f3834a3a0f5ae76b56cf5aa497d2d033384fc7d73",
+                "sha256:cb2839ccfcba0d2d3c1131d3c3e26dfc327326fbe7a5dc0dbfe9f6c9151bb022"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==1.0.4"
         },
         "httptools": {
             "hashes": [
@@ -117,6 +148,15 @@
             ],
             "version": "==0.6.1"
         },
+        "httpx": {
+            "hashes": [
+                "sha256:71d5465162c13681bff01ad59b2cc68dd838ea1f10e51574bac27103f00c91a5",
+                "sha256:a0cb88a46f32dc874e04ee956e4c2764aba2aa228f650b06788ba6bda2962ab5"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.8'",
+            "version": "==0.27.0"
+        },
         "idna": {
             "hashes": [
                 "sha256:9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca",
@@ -125,98 +165,114 @@
             "markers": "python_version >= '3.5'",
             "version": "==3.6"
         },
+        "jmespath": {
+            "hashes": [
+                "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980",
+                "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==1.0.1"
+        },
         "pydantic": {
             "hashes": [
-                "sha256:1440966574e1b5b99cf75a13bec7b20e3512e8a61b894ae252f56275e2c465ae",
-                "sha256:ae887bd94eb404b09d86e4d12f93893bdca79d766e738528c6fa1c849f3c6bcf"
+                "sha256:72c6034df47f46ccdf81869fddb81aade68056003900a8724a4f160700016a2a",
+                "sha256:e07805c4c7f5c6826e33a1d4c9d47950d7eaf34868e2690f8594d2e30241f11f"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==2.6.0"
+            "version": "==2.6.3"
         },
         "pydantic-core": {
             "hashes": [
-                "sha256:06f0d5a1d9e1b7932477c172cc720b3b23c18762ed7a8efa8398298a59d177c7",
-                "sha256:07982b82d121ed3fc1c51faf6e8f57ff09b1325d2efccaa257dd8c0dd937acca",
-                "sha256:0f478ec204772a5c8218e30eb813ca43e34005dff2eafa03931b3d8caef87d51",
-                "sha256:102569d371fadc40d8f8598a59379c37ec60164315884467052830b28cc4e9da",
-                "sha256:10dca874e35bb60ce4f9f6665bfbfad050dd7573596608aeb9e098621ac331dc",
-                "sha256:150ba5c86f502c040b822777e2e519b5625b47813bd05f9273a8ed169c97d9ae",
-                "sha256:1661c668c1bb67b7cec96914329d9ab66755911d093bb9063c4c8914188af6d4",
-                "sha256:1a2fe7b00a49b51047334d84aafd7e39f80b7675cad0083678c58983662da89b",
-                "sha256:1ae8048cba95f382dba56766525abca438328455e35c283bb202964f41a780b0",
-                "sha256:20f724a023042588d0f4396bbbcf4cffd0ddd0ad3ed4f0d8e6d4ac4264bae81e",
-                "sha256:2133b0e412a47868a358713287ff9f9a328879da547dc88be67481cdac529118",
-                "sha256:21e3298486c4ea4e4d5cc6fb69e06fb02a4e22089304308817035ac006a7f506",
-                "sha256:21ebaa4bf6386a3b22eec518da7d679c8363fb7fb70cf6972161e5542f470798",
-                "sha256:23632132f1fd608034f1a56cc3e484be00854db845b3a4a508834be5a6435a6f",
-                "sha256:2d5bea8012df5bb6dda1e67d0563ac50b7f64a5d5858348b5c8cb5043811c19d",
-                "sha256:300616102fb71241ff477a2cbbc847321dbec49428434a2f17f37528721c4948",
-                "sha256:30a8259569fbeec49cfac7fda3ec8123486ef1b729225222f0d41d5f840b476f",
-                "sha256:399166f24c33a0c5759ecc4801f040dbc87d412c1a6d6292b2349b4c505effc9",
-                "sha256:3fac641bbfa43d5a1bed99d28aa1fded1984d31c670a95aac1bf1d36ac6ce137",
-                "sha256:42c29d54ed4501a30cd71015bf982fa95e4a60117b44e1a200290ce687d3e640",
-                "sha256:462d599299c5971f03c676e2b63aa80fec5ebc572d89ce766cd11ca8bcb56f3f",
-                "sha256:4eebbd049008eb800f519578e944b8dc8e0f7d59a5abb5924cc2d4ed3a1834ff",
-                "sha256:502c062a18d84452858f8aea1e520e12a4d5228fc3621ea5061409d666ea1706",
-                "sha256:5317c04349472e683803da262c781c42c5628a9be73f4750ac7d13040efb5d2d",
-                "sha256:5511f962dd1b9b553e9534c3b9c6a4b0c9ded3d8c2be96e61d56f933feef9e1f",
-                "sha256:561be4e3e952c2f9056fba5267b99be4ec2afadc27261505d4992c50b33c513c",
-                "sha256:601d3e42452cd4f2891c13fa8c70366d71851c1593ed42f57bf37f40f7dca3c8",
-                "sha256:644904600c15816a1f9a1bafa6aab0d21db2788abcdf4e2a77951280473f33e1",
-                "sha256:653a5dfd00f601a0ed6654a8b877b18d65ac32c9d9997456e0ab240807be6cf7",
-                "sha256:694a5e9f1f2c124a17ff2d0be613fd53ba0c26de588eb4bdab8bca855e550d95",
-                "sha256:71b4a48a7427f14679f0015b13c712863d28bb1ab700bd11776a5368135c7d60",
-                "sha256:72bf9308a82b75039b8c8edd2be2924c352eda5da14a920551a8b65d5ee89253",
-                "sha256:735dceec50fa907a3c314b84ed609dec54b76a814aa14eb90da31d1d36873a5e",
-                "sha256:73802194f10c394c2bedce7a135ba1d8ba6cff23adf4217612bfc5cf060de34c",
-                "sha256:780daad9e35b18d10d7219d24bfb30148ca2afc309928e1d4d53de86822593dc",
-                "sha256:8655f55fe68c4685673265a650ef71beb2d31871c049c8b80262026f23605ee3",
-                "sha256:877045a7969ace04d59516d5d6a7dee13106822f99a5d8df5e6822941f7bedc8",
-                "sha256:87bce04f09f0552b66fca0c4e10da78d17cb0e71c205864bab4e9595122cb9d9",
-                "sha256:8d4dfc66abea3ec6d9f83e837a8f8a7d9d3a76d25c9911735c76d6745950e62c",
-                "sha256:8ec364e280db4235389b5e1e6ee924723c693cbc98e9d28dc1767041ff9bc388",
-                "sha256:8fa00fa24ffd8c31fac081bf7be7eb495be6d248db127f8776575a746fa55c95",
-                "sha256:920c4897e55e2881db6a6da151198e5001552c3777cd42b8a4c2f72eedc2ee91",
-                "sha256:920f4633bee43d7a2818e1a1a788906df5a17b7ab6fe411220ed92b42940f818",
-                "sha256:9795f56aa6b2296f05ac79d8a424e94056730c0b860a62b0fdcfe6340b658cc8",
-                "sha256:98f0edee7ee9cc7f9221af2e1b95bd02810e1c7a6d115cfd82698803d385b28f",
-                "sha256:99c095457eea8550c9fa9a7a992e842aeae1429dab6b6b378710f62bfb70b394",
-                "sha256:99d3a433ef5dc3021c9534a58a3686c88363c591974c16c54a01af7efd741f13",
-                "sha256:99f9a50b56713a598d33bc23a9912224fc5d7f9f292444e6664236ae471ddf17",
-                "sha256:9c46e556ee266ed3fb7b7a882b53df3c76b45e872fdab8d9cf49ae5e91147fd7",
-                "sha256:9f5d37ff01edcbace53a402e80793640c25798fb7208f105d87a25e6fcc9ea06",
-                "sha256:a0b4cfe408cd84c53bab7d83e4209458de676a6ec5e9c623ae914ce1cb79b96f",
-                "sha256:a497be217818c318d93f07e14502ef93d44e6a20c72b04c530611e45e54c2196",
-                "sha256:ac89ccc39cd1d556cc72d6752f252dc869dde41c7c936e86beac5eb555041b66",
-                "sha256:adf28099d061a25fbcc6531febb7a091e027605385de9fe14dd6a97319d614cf",
-                "sha256:afa01d25769af33a8dac0d905d5c7bb2d73c7c3d5161b2dd6f8b5b5eea6a3c4c",
-                "sha256:b1fc07896fc1851558f532dffc8987e526b682ec73140886c831d773cef44b76",
-                "sha256:b49c604ace7a7aa8af31196abbf8f2193be605db6739ed905ecaf62af31ccae0",
-                "sha256:b9f3e0bffad6e238f7acc20c393c1ed8fab4371e3b3bc311020dfa6020d99212",
-                "sha256:ba07646f35e4e49376c9831130039d1b478fbfa1215ae62ad62d2ee63cf9c18f",
-                "sha256:bd88f40f2294440d3f3c6308e50d96a0d3d0973d6f1a5732875d10f569acef49",
-                "sha256:c0be58529d43d38ae849a91932391eb93275a06b93b79a8ab828b012e916a206",
-                "sha256:c45f62e4107ebd05166717ac58f6feb44471ed450d07fecd90e5f69d9bf03c48",
-                "sha256:c56da23034fe66221f2208c813d8aa509eea34d97328ce2add56e219c3a9f41c",
-                "sha256:c94b5537bf6ce66e4d7830c6993152940a188600f6ae044435287753044a8fe2",
-                "sha256:cebf8d56fee3b08ad40d332a807ecccd4153d3f1ba8231e111d9759f02edfd05",
-                "sha256:d0bf6f93a55d3fa7a079d811b29100b019784e2ee6bc06b0bb839538272a5610",
-                "sha256:d195add190abccefc70ad0f9a0141ad7da53e16183048380e688b466702195dd",
-                "sha256:d25ef0c33f22649b7a088035fd65ac1ce6464fa2876578df1adad9472f918a76",
-                "sha256:d6cbdf12ef967a6aa401cf5cdf47850559e59eedad10e781471c960583f25aa1",
-                "sha256:d8c032ccee90b37b44e05948b449a2d6baed7e614df3d3f47fe432c952c21b60",
-                "sha256:daff04257b49ab7f4b3f73f98283d3dbb1a65bf3500d55c7beac3c66c310fe34",
-                "sha256:e83ebbf020be727d6e0991c1b192a5c2e7113eb66e3def0cd0c62f9f266247e4",
-                "sha256:ed3025a8a7e5a59817b7494686d449ebfbe301f3e757b852c8d0d1961d6be864",
-                "sha256:f1936ef138bed2165dd8573aa65e3095ef7c2b6247faccd0e15186aabdda7f66",
-                "sha256:f5247a3d74355f8b1d780d0f3b32a23dd9f6d3ff43ef2037c6dcd249f35ecf4c",
-                "sha256:fa496cd45cda0165d597e9d6f01e36c33c9508f75cf03c0a650018c5048f578e",
-                "sha256:fb4363e6c9fc87365c2bc777a1f585a22f2f56642501885ffc7942138499bf54",
-                "sha256:fb4370b15111905bf8b5ba2129b926af9470f014cb0493a67d23e9d7a48348e8",
-                "sha256:fbec2af0ebafa57eb82c18c304b37c86a8abddf7022955d1742b3d5471a6339e"
+                "sha256:00ee1c97b5364b84cb0bd82e9bbf645d5e2871fb8c58059d158412fee2d33d8a",
+                "sha256:0d32576b1de5a30d9a97f300cc6a3f4694c428d956adbc7e6e2f9cad279e45ed",
+                "sha256:0df446663464884297c793874573549229f9eca73b59360878f382a0fc085979",
+                "sha256:0f56ae86b60ea987ae8bcd6654a887238fd53d1384f9b222ac457070b7ac4cff",
+                "sha256:13dcc4802961b5f843a9385fc821a0b0135e8c07fc3d9949fd49627c1a5e6ae5",
+                "sha256:162e498303d2b1c036b957a1278fa0899d02b2842f1ff901b6395104c5554a45",
+                "sha256:1b662180108c55dfbf1280d865b2d116633d436cfc0bba82323554873967b340",
+                "sha256:1cac689f80a3abab2d3c0048b29eea5751114054f032a941a32de4c852c59cad",
+                "sha256:21b888c973e4f26b7a96491c0965a8a312e13be108022ee510248fe379a5fa23",
+                "sha256:287073c66748f624be4cef893ef9174e3eb88fe0b8a78dc22e88eca4bc357ca6",
+                "sha256:2a1ef6a36fdbf71538142ed604ad19b82f67b05749512e47f247a6ddd06afdc7",
+                "sha256:2a72fb9963cba4cd5793854fd12f4cfee731e86df140f59ff52a49b3552db241",
+                "sha256:2acca2be4bb2f2147ada8cac612f8a98fc09f41c89f87add7256ad27332c2fda",
+                "sha256:2f583bd01bbfbff4eaee0868e6fc607efdfcc2b03c1c766b06a707abbc856187",
+                "sha256:33809aebac276089b78db106ee692bdc9044710e26f24a9a2eaa35a0f9fa70ba",
+                "sha256:36fa178aacbc277bc6b62a2c3da95226520da4f4e9e206fdf076484363895d2c",
+                "sha256:4204e773b4b408062960e65468d5346bdfe139247ee5f1ca2a378983e11388a2",
+                "sha256:4384a8f68ddb31a0b0c3deae88765f5868a1b9148939c3f4121233314ad5532c",
+                "sha256:456855f57b413f077dff513a5a28ed838dbbb15082ba00f80750377eed23d132",
+                "sha256:49d5d58abd4b83fb8ce763be7794d09b2f50f10aa65c0f0c1696c677edeb7cbf",
+                "sha256:4ac6b4ce1e7283d715c4b729d8f9dab9627586dafce81d9eaa009dd7f25dd972",
+                "sha256:4df8a199d9f6afc5ae9a65f8f95ee52cae389a8c6b20163762bde0426275b7db",
+                "sha256:500960cb3a0543a724a81ba859da816e8cf01b0e6aaeedf2c3775d12ee49cade",
+                "sha256:519ae0312616026bf4cedc0fe459e982734f3ca82ee8c7246c19b650b60a5ee4",
+                "sha256:578114bc803a4c1ff9946d977c221e4376620a46cf78da267d946397dc9514a8",
+                "sha256:5c5cbc703168d1b7a838668998308018a2718c2130595e8e190220238addc96f",
+                "sha256:6162f8d2dc27ba21027f261e4fa26f8bcb3cf9784b7f9499466a311ac284b5b9",
+                "sha256:704d35ecc7e9c31d48926150afada60401c55efa3b46cd1ded5a01bdffaf1d48",
+                "sha256:716b542728d4c742353448765aa7cdaa519a7b82f9564130e2b3f6766018c9ec",
+                "sha256:72282ad4892a9fb2da25defeac8c2e84352c108705c972db82ab121d15f14e6d",
+                "sha256:7233d65d9d651242a68801159763d09e9ec96e8a158dbf118dc090cd77a104c9",
+                "sha256:732da3243e1b8d3eab8c6ae23ae6a58548849d2e4a4e03a1924c8ddf71a387cb",
+                "sha256:75b81e678d1c1ede0785c7f46690621e4c6e63ccd9192af1f0bd9d504bbb6bf4",
+                "sha256:75f76ee558751746d6a38f89d60b6228fa174e5172d143886af0f85aa306fd89",
+                "sha256:7ee8d5f878dccb6d499ba4d30d757111847b6849ae07acdd1205fffa1fc1253c",
+                "sha256:7f752826b5b8361193df55afcdf8ca6a57d0232653494ba473630a83ba50d8c9",
+                "sha256:86b3d0033580bd6bbe07590152007275bd7af95f98eaa5bd36f3da219dcd93da",
+                "sha256:8d62da299c6ecb04df729e4b5c52dc0d53f4f8430b4492b93aa8de1f541c4aac",
+                "sha256:8e47755d8152c1ab5b55928ab422a76e2e7b22b5ed8e90a7d584268dd49e9c6b",
+                "sha256:9091632a25b8b87b9a605ec0e61f241c456e9248bfdcf7abdf344fdb169c81cf",
+                "sha256:936e5db01dd49476fa8f4383c259b8b1303d5dd5fb34c97de194560698cc2c5e",
+                "sha256:99b6add4c0b39a513d323d3b93bc173dac663c27b99860dd5bf491b240d26137",
+                "sha256:9c865a7ee6f93783bd5d781af5a4c43dadc37053a5b42f7d18dc019f8c9d2bd1",
+                "sha256:a425479ee40ff021f8216c9d07a6a3b54b31c8267c6e17aa88b70d7ebd0e5e5b",
+                "sha256:a4b2bf78342c40b3dc830880106f54328928ff03e357935ad26c7128bbd66ce8",
+                "sha256:a6b1bb0827f56654b4437955555dc3aeeebeddc47c2d7ed575477f082622c49e",
+                "sha256:aaf09e615a0bf98d406657e0008e4a8701b11481840be7d31755dc9f97c44053",
+                "sha256:b1f6f5938d63c6139860f044e2538baeee6f0b251a1816e7adb6cbce106a1f01",
+                "sha256:b29eeb887aa931c2fcef5aa515d9d176d25006794610c264ddc114c053bf96fe",
+                "sha256:b3992a322a5617ded0a9f23fd06dbc1e4bd7cf39bc4ccf344b10f80af58beacd",
+                "sha256:b5b6079cc452a7c53dd378c6f881ac528246b3ac9aae0f8eef98498a75657805",
+                "sha256:b60cc1a081f80a2105a59385b92d82278b15d80ebb3adb200542ae165cd7d183",
+                "sha256:b926dd38db1519ed3043a4de50214e0d600d404099c3392f098a7f9d75029ff8",
+                "sha256:bd87f48924f360e5d1c5f770d6155ce0e7d83f7b4e10c2f9ec001c73cf475c99",
+                "sha256:bda1ee3e08252b8d41fa5537413ffdddd58fa73107171a126d3b9ff001b9b820",
+                "sha256:be0ec334369316fa73448cc8c982c01e5d2a81c95969d58b8f6e272884df0074",
+                "sha256:c6119dc90483a5cb50a1306adb8d52c66e447da88ea44f323e0ae1a5fcb14256",
+                "sha256:c9803edf8e29bd825f43481f19c37f50d2b01899448273b3a7758441b512acf8",
+                "sha256:c9bd22a2a639e26171068f8ebb5400ce2c1bc7d17959f60a3b753ae13c632975",
+                "sha256:cbcc558401de90a746d02ef330c528f2e668c83350f045833543cd57ecead1ad",
+                "sha256:cf6204fe865da605285c34cf1172879d0314ff267b1c35ff59de7154f35fdc2e",
+                "sha256:d33dd21f572545649f90c38c227cc8631268ba25c460b5569abebdd0ec5974ca",
+                "sha256:d89ca19cdd0dd5f31606a9329e309d4fcbb3df860960acec32630297d61820df",
+                "sha256:d8f99b147ff3fcf6b3cc60cb0c39ea443884d5559a30b1481e92495f2310ff2b",
+                "sha256:d937653a696465677ed583124b94a4b2d79f5e30b2c46115a68e482c6a591c8a",
+                "sha256:dcca5d2bf65c6fb591fff92da03f94cd4f315972f97c21975398bd4bd046854a",
+                "sha256:ded1c35f15c9dea16ead9bffcde9bb5c7c031bff076355dc58dcb1cb436c4721",
+                "sha256:e3e70c94a0c3841e6aa831edab1619ad5c511199be94d0c11ba75fe06efe107a",
+                "sha256:e56f8186d6210ac7ece503193ec84104da7ceb98f68ce18c07282fcc2452e76f",
+                "sha256:e7774b570e61cb998490c5235740d475413a1f6de823169b4cf94e2fe9e9f6b2",
+                "sha256:e7c6ed0dc9d8e65f24f5824291550139fe6f37fac03788d4580da0d33bc00c97",
+                "sha256:ec08be75bb268473677edb83ba71e7e74b43c008e4a7b1907c6d57e940bf34b6",
+                "sha256:ecdf6bf5f578615f2e985a5e1f6572e23aa632c4bd1dc67f8f406d445ac115ed",
+                "sha256:ed25e1835c00a332cb10c683cd39da96a719ab1dfc08427d476bce41b92531fc",
+                "sha256:f4cb85f693044e0f71f394ff76c98ddc1bc0953e48c061725e540396d5c8a2e1",
+                "sha256:f53aace168a2a10582e570b7736cc5bef12cae9cf21775e3eafac597e8551fbe",
+                "sha256:f651dd19363c632f4abe3480a7c87a9773be27cfe1341aef06e8759599454120",
+                "sha256:fc4ad7f7ee1a13d9cb49d8198cd7d7e3aa93e425f371a68235f784e99741561f",
+                "sha256:fee427241c2d9fb7192b658190f9f5fd6dfe41e02f3c1489d2ec1e6a5ab1e04a"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==2.16.1"
+            "version": "==2.16.3"
+        },
+        "python-dateutil": {
+            "hashes": [
+                "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
+                "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.8.2"
         },
         "python-dotenv": {
             "hashes": [
@@ -224,6 +280,15 @@
                 "sha256:f7b63ef50f1b690dddf550d03497b66d609393b40b564ed0d674909a68ebf16a"
             ],
             "version": "==1.0.1"
+        },
+        "python-multipart": {
+            "hashes": [
+                "sha256:03f54688c663f1b7977105f021043b0793151e4cb1c1a9d4a11fc13d622c4026",
+                "sha256:97ca7b8ea7b05f977dc3849c3ba99d51689822fab725c3703af7c866a0c2b215"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.8'",
+            "version": "==0.0.9"
         },
         "pyyaml": {
             "hashes": [
@@ -281,20 +346,13 @@
             ],
             "version": "==6.0.1"
         },
-        "save": {
+        "s3transfer": {
             "hashes": [
-                "sha256:5b93591b8c0b3e37a715eaaf120eecaf9fd7b8580f45f8d018fefa41bb3eb1eb"
+                "sha256:3cdb40f5cfa6966e812209d0994f2a4709b561c88e90cf00c2696d2df4e56b2e",
+                "sha256:d0c8bbf672d5eebbe4e57945e23b972d963f07d82f661cabf678a5c88831595b"
             ],
-            "index": "pypi",
-            "version": "==0.1"
-        },
-        "services": {
-            "hashes": [
-                "sha256:d267e6a80c2edf7341b0eba027e14a7b1645d5c5e2e81737a18237d241224e17",
-                "sha256:fb508e10a47f6c8efa232c3a5446542cf81fa4bcd8afa69c7ab824ff45ef0ea5"
-            ],
-            "index": "pypi",
-            "version": "==0.1.1"
+            "markers": "python_version >= '3.8'",
+            "version": "==0.10.0"
         },
         "six": {
             "hashes": [
@@ -306,38 +364,46 @@
         },
         "sniffio": {
             "hashes": [
-                "sha256:e60305c5e5d314f5389259b7f22aaa33d8f7dee49763119234af3755c55b9101",
-                "sha256:eecefdce1e5bbfb7ad2eeaabf7c1eeb404d7757c379bd1f7e5cce9d8bf425384"
+                "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2",
+                "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.3.0"
+            "version": "==1.3.1"
         },
         "starlette": {
             "hashes": [
-                "sha256:3e2639dac3520e4f58734ed22553f950d3f3cb1001cd2eaac4d57e8cdc5f66bc",
-                "sha256:50bbbda9baa098e361f398fda0928062abbaf1f54f4fadcbe17c092a01eb9a25"
+                "sha256:13d429aa93a61dc40bf503e8c801db1f1bca3dc706b10ef2434a36123568f044",
+                "sha256:90a671733cfb35771d8cc605e0b679d23b992f8dcfad48cc60b38cb29aeb7080"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==0.35.1"
+            "version": "==0.36.3"
         },
         "typing-extensions": {
             "hashes": [
-                "sha256:23478f88c37f27d76ac8aee6c905017a143b0b1b886c3c9f66bc2fd94f9f5783",
-                "sha256:af72aea155e91adfc61c3ae9e0e342dbc0cba726d6cba4b6c72c1f34e47291cd"
+                "sha256:69b1a937c3a517342112fb4c6df7e72fc39a38e7891a5730ed4985b5214b5475",
+                "sha256:b0abd7c89e8fb96f98db18d86106ff1d90ab692004eb746cf6eda2682f91b3cb"
             ],
             "markers": "python_version < '3.11'",
-            "version": "==4.9.0"
+            "version": "==4.10.0"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:34b97092d7e0a3a8cf7cd10e386f401b3737364026c45e622aa02903dffe0f07",
+                "sha256:f8ecc1bba5667413457c529ab955bf8c67b45db799d159066261719e328580a0"
+            ],
+            "markers": "python_version < '3.10'",
+            "version": "==1.26.18"
         },
         "uvicorn": {
             "extras": [
                 "standard"
             ],
             "hashes": [
-                "sha256:4b85ba02b8a20429b9b205d015cbeb788a12da527f731811b643fd739ef90d5f",
-                "sha256:54898fcd80c13ff1cd28bf77b04ec9dbd8ff60c5259b499b4b12bb0917f22907"
+                "sha256:3d9a267296243532db80c83a959a3400502165ade2c1338dea4e67915fd4745a",
+                "sha256:5c89da2f3895767472a35556e539fd59f7edbe9b1e9c0e1c99eebeadc61838e4"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==0.27.0.post1"
+            "version": "==0.27.1"
         },
         "uvloop": {
             "hashes": [
@@ -374,14 +440,6 @@
                 "sha256:f467a5fd23b4fc43ed86342641f3936a68ded707f4627622fa3f82a120e18256"
             ],
             "version": "==0.19.0"
-        },
-        "validation": {
-            "hashes": [
-                "sha256:c4aed7dd548b5ad3ba12306cda7322658490e22dedef29295fdb8692b1b4fe3a"
-            ],
-            "index": "pypi",
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==0.8.3"
         },
         "watchfiles": {
             "hashes": [
@@ -541,5 +599,64 @@
             "version": "==12.0"
         }
     },
-    "develop": {}
+    "develop": {
+        "exceptiongroup": {
+            "hashes": [
+                "sha256:4bfd3996ac73b41e9b9628b04e079f193850720ea5945fc96a08633c66912f14",
+                "sha256:91f5c769735f051a4290d52edd0858999b57e5876e9f85937691bd4c9fa3ed68"
+            ],
+            "markers": "python_version < '3.11'",
+            "version": "==1.2.0"
+        },
+        "iniconfig": {
+            "hashes": [
+                "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3",
+                "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==2.0.0"
+        },
+        "packaging": {
+            "hashes": [
+                "sha256:048fb0e9405036518eaaf48a55953c750c11e1a1b68e0dd1a9d62ed0c092cfc5",
+                "sha256:8c491190033a9af7e1d931d0b5dacc2ef47509b34dd0de67ed209b5203fc88c7"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==23.2"
+        },
+        "pluggy": {
+            "hashes": [
+                "sha256:7db9f7b503d67d1c5b95f59773ebb58a8c1c288129a88665838012cfb07b8981",
+                "sha256:8c85c2876142a764e5b7548e7d9a0e0ddb46f5185161049a79b7e974454223be"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==1.4.0"
+        },
+        "pytest": {
+            "hashes": [
+                "sha256:d4051d623a2e0b7e51960ba963193b09ce6daeb9759a451844a21e4ddedfc1bd",
+                "sha256:edfaaef32ce5172d5466b5127b42e0d6d35ebbe4453f0e3505d96afd93f6b096"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.8'",
+            "version": "==8.0.2"
+        },
+        "pytest-asyncio": {
+            "hashes": [
+                "sha256:3a048872a9c4ba14c3e90cc1aa20cbc2def7d01c7c8db3777ec281ba9c057675",
+                "sha256:4e7093259ba018d58ede7d5315131d21923a60f8a6e9ee266ce1589685c89eac"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.8'",
+            "version": "==0.23.5"
+        },
+        "tomli": {
+            "hashes": [
+                "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
+                "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
+            ],
+            "markers": "python_version < '3.11'",
+            "version": "==2.0.1"
+        }
+    }
 }

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ You will need to install Docker from the following link [Docker](https://docs.do
 
 #### Starting Docker services
 Before running the services make sure Docker is started. Then proceed to run the following command from the root of the project.
-This should start up localstack and clamav
+This should start up localstack  clamav and dynamodb
     
     docker compose up
 
@@ -73,9 +73,22 @@ Listing objects inside buckets
     
     aws --endpoint-url=http://localhost:4566 s3 ls s3://ss-poc-test
 
+## DynamoDb
+By starting docker services using docker compose you get a blank canvas  and you will need to add a
+configuration to the db in order to play around with the api.
+
+The simplest way to add a config for now is to run the  ```./dynamo-script.sh``` in the route directory.
+In general we will manage this config some other way in production but for local environment its handy having this.
+
+### What is configurable
+1. Fle Extension
+2. File Content type
+
+We will extend this to include file size at some point
+
 ## Postman
 
-This repository impliments Postman for its API testing. There is some setup required to enable the Postman collection to view the files required for the requests
+This repository implements Postman for its API testing. There is some setup required to enable the Postman collection to view the files required for the requests
 
 ### Microsoft Defender
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,4 +17,9 @@ services:
       - "3310:3310"
     volumes:
       - ./data/clamav/definitions:/var/lib/clamav
+  dynamodb:
+    image: amazon/dynamodb-local
+    container_name: dynamodb_local
+    ports:
+      - "8000:8000"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,5 +21,5 @@ services:
     image: amazon/dynamodb-local
     container_name: dynamodb_local
     ports:
-      - "8000:8000"
+      - "8100:8000"
 

--- a/dynamo-script.sh
+++ b/dynamo-script.sh
@@ -2,16 +2,16 @@
 
 TABLE_NAME="SERVICE_CONFIG"
 
-if ! aws dynamodb list-tables --endpoint-url http://localhost:8000 | grep -q "$TABLE_NAME"; then
+if ! aws dynamodb list-tables --endpoint-url http://localhost:8100 | grep -q "$TABLE_NAME"; then
     aws dynamodb create-table --table-name $TABLE_NAME \
     --attribute-definitions AttributeName=service_id,AttributeType=S \
     --key-schema AttributeName=service_id,KeyType=HASH \
     --provisioned-throughput ReadCapacityUnits=5,WriteCapacityUnits=5 \
-    --endpoint-url http://localhost:8000
+    --endpoint-url http://localhost:8100
 
 
     aws dynamodb wait table-exists --table-name $TABLE_NAME \
-    --endpoint-url http://localhost:8000
+    --endpoint-url http://localhost:8100
 fi
 
 aws dynamodb put-item --table-name SERVICE_CONFIG --item \
@@ -19,4 +19,4 @@ aws dynamodb put-item --table-name SERVICE_CONFIG --item \
   "service_id": {"S": "1234"},
   "acceptedExtensions": {"SS": [".pdf", ".doc", ".docx", ".txt"]},
   "acceptedContentTypes": {"SS": ["application/pdf", "application/msword", "application/vnd.openxmlformats-officedocument.wordprocessingml.document", "text/plain"]}
-}' --endpoint-url http://localhost:8000
+}' --endpoint-url http://localhost:8100

--- a/dynamo-script.sh
+++ b/dynamo-script.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+TABLE_NAME="SERVICE_CONFIG"
+
+if ! aws dynamodb list-tables --endpoint-url http://localhost:8000 | grep -q "$TABLE_NAME"; then
+    aws dynamodb create-table --table-name $TABLE_NAME \
+    --attribute-definitions AttributeName=service_id,AttributeType=S \
+    --key-schema AttributeName=service_id,KeyType=HASH \
+    --provisioned-throughput ReadCapacityUnits=5,WriteCapacityUnits=5 \
+    --endpoint-url http://localhost:8000
+
+
+    aws dynamodb wait table-exists --table-name $TABLE_NAME \
+    --endpoint-url http://localhost:8000
+fi
+
+aws dynamodb put-item --table-name SERVICE_CONFIG --item \
+'{
+  "service_id": {"S": "1234"},
+  "acceptedExtensions": {"SS": [".pdf", ".doc", ".docx", ".txt"]},
+  "acceptedContentTypes": {"SS": ["application/pdf", "application/msword", "application/vnd.openxmlformats-officedocument.wordprocessingml.document", "text/plain"]}
+}' --endpoint-url http://localhost:8000

--- a/src/config/config_resolver.py
+++ b/src/config/config_resolver.py
@@ -1,5 +1,6 @@
-import os
 import json
+import os
+
 from models.config.file_types_config import AcceptedFileTypes
 
 

--- a/src/models/config/file_types_config.py
+++ b/src/models/config/file_types_config.py
@@ -1,5 +1,6 @@
-from pydantic import BaseModel, Field
 from typing import List
+
+from pydantic import BaseModel
 
 
 class AcceptedFileTypes(BaseModel):

--- a/src/routers/upload_file.py
+++ b/src/routers/upload_file.py
@@ -1,8 +1,8 @@
 from fastapi import APIRouter, UploadFile, Request, HTTPException
 from fastapi.responses import JSONResponse
+
 from services.s3_service import save as saveToS3
 from validation.validator import validate_request
-
 
 router = APIRouter()
 

--- a/src/services/config_service.py
+++ b/src/services/config_service.py
@@ -1,0 +1,49 @@
+import os
+import boto3
+from models.config.file_types_config import AcceptedFileTypes
+
+
+class DynamoDBService:
+    _instance = None
+
+    @staticmethod
+    def get_instance():
+        if DynamoDBService._instance is None:
+            DynamoDBService()
+        return DynamoDBService._instance
+
+    def __init__(self):
+        if DynamoDBService._instance is not None:
+            raise Exception("This class is a singleton!")
+        else:
+            DynamoDBService._instance = self
+
+        table_name = os.getenv('CONFIG_TABLE', 'SERVICE_CONFIG')
+
+        # Check whether the application is running in a local development
+        # environment or in production
+        is_local = os.getenv('IS_LOCAL', False)
+
+        if is_local:
+            self._dynamodb = boto3.resource('dynamodb', endpoint_url='http://localhost:8000')
+        else:
+            region_name = os.getenv('AWS_REGION', 'us-east-1')
+            self._dynamodb = boto3.resource('dynamodb', region_name=region_name)
+
+        self._config = self._dynamodb.Table(table_name)
+
+    def read_config(self, key: str) -> AcceptedFileTypes:
+        response = self._config.get_item(Key={'service_id': key})
+        item = response.get('Item')
+
+        if not item:
+            return None
+
+        config = AcceptedFileTypes(**item)
+        return config
+
+
+async def get_accepted_file_type_config(key:str) -> AcceptedFileTypes:
+    dynamodb_service = DynamoDBService.get_instance()
+    return dynamodb_service.read_config(key)
+

--- a/src/services/config_service.py
+++ b/src/services/config_service.py
@@ -1,5 +1,7 @@
 import os
+
 import boto3
+
 from models.config.file_types_config import AcceptedFileTypes
 
 
@@ -25,7 +27,7 @@ class DynamoDBService:
         is_local = os.getenv('IS_LOCAL', False)
 
         if is_local:
-            self._dynamodb = boto3.resource('dynamodb', endpoint_url='http://localhost:8000')
+            self._dynamodb = boto3.resource('dynamodb', endpoint_url='http://localhost:8100')
         else:
             region_name = os.getenv('AWS_REGION', 'us-east-1')
             self._dynamodb = boto3.resource('dynamodb', region_name=region_name)

--- a/src/services/s3_service.py
+++ b/src/services/s3_service.py
@@ -1,7 +1,8 @@
 import os
+from io import BytesIO
+
 import boto3
 from botocore.exceptions import ClientError
-from io import BytesIO
 from dotenv import load_dotenv
 
 bucket = 'ss-poc-test'

--- a/src/validation/validator.py
+++ b/src/validation/validator.py
@@ -2,16 +2,19 @@ import inspect
 import io
 
 from fastapi import Header, UploadFile
+
+from models.config.file_types_config import AcceptedFileTypes
 from models.validation_response import ValidationResponse
 from services.av_check_service import virus_check
-from config.config_resolver import get_accepted_file_type_config
+from services.config_service import get_accepted_file_type_config
 
-acceptedFileTypeConfig = get_accepted_file_type_config()
+
 
 
 async def validate_request(headers: Header, file: UploadFile):
     messages = []
     status_code = None
+    acceptedFileTypeConfig = await get_accepted_file_type_config("service-team-1")
     validator_sequence = [content_length_is_present,
                           content_expected_fail_for_no_file_received,
                           content_length_is_more_than_file_size,
@@ -22,9 +25,9 @@ async def validate_request(headers: Header, file: UploadFile):
 
     for validator in validator_sequence:
         if inspect.iscoroutinefunction(validator):
-            code, message = await validator(headers, file)
+            code, message = await validator(headers, file,acceptedFileTypeConfig)
         else:
-            code, message = validator(headers, file)
+            code, message = validator(headers, file,acceptedFileTypeConfig)
 
         if code != 200:
             messages.append(message)
@@ -36,14 +39,14 @@ async def validate_request(headers: Header, file: UploadFile):
     return ValidationResponse(status_code=status_code, message=messages)
 
 
-def content_length_is_present(headers: Header, file: UploadFile):
+def content_length_is_present(headers: Header, file: UploadFile,acceptedFileTypeConfig):
     if headers.get('content-length') is not None:
         return 200, ""
     else:
         return 411, "content-length header not found"
 
 
-def content_length_is_more_than_file_size(headers: Header, file: UploadFile):
+def content_length_is_more_than_file_size(headers: Header, file: UploadFile,acceptedFileTypeConfig:AcceptedFileTypes):
     content_length = headers.get('content-length')
     if content_length is not None and file is not None and int(content_length) > file.size:
         return 200, ""
@@ -51,35 +54,35 @@ def content_length_is_more_than_file_size(headers: Header, file: UploadFile):
         return 400, "Content length does not exceed file size or required parameters are missing"
 
 
-def file_size_is_below_maximum(headers: Header, file: UploadFile):
+def file_size_is_below_maximum(headers: Header, file: UploadFile,acceptedFileTypeConfig:AcceptedFileTypes):
     if file is not None and file.size <= 2000000:
         return 200, ""
     else:
         return 413, "File size suspiciously large (over 2000000 bytes)"
 
 
-def content_expected_fail_for_no_file_received(headers: Header, file: UploadFile):
+def content_expected_fail_for_no_file_received(headers: Header, file: UploadFile,acceptedFileTypeConfig:AcceptedFileTypes):
     if file is None:
         return 400, "No file received"
     else:
         return 200, ""
 
 
-def file_has_right_extension(headers: Header, file: UploadFile):
+def file_has_right_extension(headers: Header, file: UploadFile, acceptedFileTypeConfig:AcceptedFileTypes):
     for fileType in acceptedFileTypeConfig.acceptedExtensions:
         if file.filename.endswith(fileType):
             return 200, ""
     return 415, "File extension is not PDF, DOC or TXT"
 
 
-def file_has_right_content_type(headers: Header, file: UploadFile):
+def file_has_right_content_type(headers: Header, file: UploadFile,acceptedFileTypeConfig:AcceptedFileTypes):
     for contentType in acceptedFileTypeConfig.acceptedContentTypes:
         if file.content_type == contentType:
             return 200, ""
     return 415, "File is of wrong content type"
 
 
-async def check_antivirus(headers: Header, file: UploadFile):
+async def check_antivirus(headers: Header, file: UploadFile, acceptedFileTypeConfig:AcceptedFileTypes):
     file_content = await file.read()
     response, status = await virus_check(io.BytesIO(file_content))
     if status == 200:

--- a/src/validation/validator.py
+++ b/src/validation/validator.py
@@ -2,19 +2,17 @@ import inspect
 import io
 
 from fastapi import Header, UploadFile
+from models.validation_response import ValidationResponse
 
 from models.config.file_types_config import AcceptedFileTypes
-from models.validation_response import ValidationResponse
 from services.av_check_service import virus_check
 from services.config_service import get_accepted_file_type_config
-
-
 
 
 async def validate_request(headers: Header, file: UploadFile):
     messages = []
     status_code = None
-    acceptedFileTypeConfig = await get_accepted_file_type_config("service-team-1")
+    acceptedFileTypeConfig = await get_accepted_file_type_config("1234")
     validator_sequence = [content_length_is_present,
                           content_expected_fail_for_no_file_received,
                           content_length_is_more_than_file_size,

--- a/tests/routers/test_upload_file.py
+++ b/tests/routers/test_upload_file.py
@@ -1,8 +1,8 @@
-from fastapi.testclient import TestClient
-
-from main import app
-import pytest
 from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+from main import app
 from models.validation_response import ValidationResponse
 
 testClient = TestClient(app)

--- a/tests/services/test_av_check_service.py
+++ b/tests/services/test_av_check_service.py
@@ -1,7 +1,7 @@
-import asyncio
-import pytest
-from unittest.mock import AsyncMock, patch
 from io import BytesIO
+from unittest.mock import patch
+
+import pytest
 from services.av_check_service import AvCheckService
 
 

--- a/tests/services/test_config_service.py
+++ b/tests/services/test_config_service.py
@@ -1,6 +1,7 @@
 import os
+from unittest.mock import patch
+
 import pytest
-from unittest.mock import MagicMock, patch
 from models.config.file_types_config import AcceptedFileTypes
 from services.config_service import DynamoDBService, get_accepted_file_type_config
 

--- a/tests/services/test_config_service.py
+++ b/tests/services/test_config_service.py
@@ -1,0 +1,28 @@
+import os
+import pytest
+from unittest.mock import MagicMock, patch
+from models.config.file_types_config import AcceptedFileTypes
+from services.config_service import DynamoDBService, get_accepted_file_type_config
+
+
+@pytest.mark.asyncio
+@patch.object(DynamoDBService.get_instance(), '_config')
+@patch.object(DynamoDBService.get_instance(), '_dynamodb')
+@pytest.mark.parametrize("db_response,expected_result", [
+    (
+            {"Item": {"acceptedExtensions": ["png"], "acceptedContentTypes": ["image/png"]}},
+            AcceptedFileTypes(acceptedExtensions=["png"], acceptedContentTypes=["image/png"])
+    )
+])
+async def test_read_config_item_exists(mocked_dynamodb, mocked_config, db_response, expected_result):
+    os.environ["IS_LOCAL"] = "True"
+
+    mocked_dynamodb.Table.return_value = mocked_config
+    mocked_config.get_item.return_value = db_response
+
+    result = await get_accepted_file_type_config('1234')
+
+    assert result.acceptedExtensions == expected_result.acceptedExtensions
+    assert result.acceptedContentTypes == expected_result.acceptedContentTypes
+
+    mocked_config.get_item.assert_called_once_with(Key={'service_id': '1234'})

--- a/tests/services/test_s3_service.py
+++ b/tests/services/test_s3_service.py
@@ -1,4 +1,3 @@
-from fastapi.testclient import TestClient
 from services.s3_service import save
 from unittest.mock import patch, Mock
 from botocore.exceptions import ClientError

--- a/tests/validation_tests/test_validation_file.py
+++ b/tests/validation_tests/test_validation_file.py
@@ -1,10 +1,8 @@
-import pytest
-
-from services.config_service import get_accepted_file_type_config
-from validation.validator import validate_request
 from unittest.mock import patch
-from models.config.file_types_config import AcceptedFileTypes
 
+import pytest
+from models.config.file_types_config import AcceptedFileTypes
+from validation.validator import validate_request
 
 
 @pytest.mark.asyncio

--- a/tests/validation_tests/test_validation_file.py
+++ b/tests/validation_tests/test_validation_file.py
@@ -1,6 +1,6 @@
 import pytest
 
-import validation.validator
+from services.config_service import get_accepted_file_type_config
 from validation.validator import validate_request
 from unittest.mock import patch
 from models.config.file_types_config import AcceptedFileTypes
@@ -8,70 +8,90 @@ from models.config.file_types_config import AcceptedFileTypes
 
 
 @pytest.mark.asyncio
-async def test_expected_fail_for_no_content_length_header(get_default_mock_file):
+@patch("validation.validator.get_accepted_file_type_config")
+async def test_expected_fail_for_no_content_length_header(get_accepted_file_type_config,get_default_mock_file):
     test_header = {}
-
+    get_accepted_file_type_config.return_value = AcceptedFileTypes(acceptedExtensions=["png", "txt"],
+                                                                   acceptedContentTypes=["image/png", "text/plain"])
     result = await validate_request(test_header, get_default_mock_file)
     assert result.status_code == 411 and result.message == ["content-length header not found"]
 
 @pytest.mark.asyncio
-async def test_expected_fail_for_no_file_received():
+@patch("validation.validator.get_accepted_file_type_config")
+async def test_expected_fail_for_no_file_received(get_accepted_file_type_config):
     test_file = None
 
     test_header = {'content-length': 1}
+    get_accepted_file_type_config.return_value = AcceptedFileTypes(acceptedExtensions=["png", "txt"],
+                                                                   acceptedContentTypes=["image/png", "text/plain"])
 
     result = await validate_request(test_header, test_file)
     assert result.status_code == 400 and result.message == ["No file received"]
 
 @pytest.mark.asyncio
+@patch("validation.validator.get_accepted_file_type_config")
 @patch("validation.validator.virus_check")
 @pytest.mark.parametrize("filesize,content_length", [(0, 1), (2, 3)])
-async def test_expected_success_for_content_length_bigger_than_file_size(virus_check, filesize, content_length, get_default_mock_file):
+async def test_expected_success_for_content_length_bigger_than_file_size(virus_check, get_accepted_file_type_config,filesize, content_length, get_default_mock_file):
     get_default_mock_file.size = filesize
 
     virus_check.return_value = ["OK"], 200
 
     test_header = {'content-length': content_length}
 
+    get_accepted_file_type_config.return_value = AcceptedFileTypes(acceptedExtensions=["png", "txt"],
+                                                                   acceptedContentTypes=["image/png", "text/plain"])
+
     result = await validate_request(test_header, get_default_mock_file)
 
     assert result.status_code == 200 and result.message == []
 
 @pytest.mark.asyncio
-async def test_expected_fail_for_file_too_long(get_default_mock_file):
+@patch("validation.validator.get_accepted_file_type_config")
+async def test_expected_fail_for_file_too_long(get_accepted_file_type_config,get_default_mock_file):
     get_default_mock_file.size = 2000001
 
     test_header = {'content-length': 2000002}
+    get_accepted_file_type_config.return_value = AcceptedFileTypes(acceptedExtensions=["png", "txt"],
+                                                                   acceptedContentTypes=["image/png", "text/plain"])
 
     result = await validate_request(test_header, get_default_mock_file)
     assert result.status_code == 413 and result.message == ["File size suspiciously large (over 2000000 bytes)"]
 
 @pytest.mark.asyncio
+@patch("validation.validator.get_accepted_file_type_config")
 @patch("validation.validator.virus_check")
 @pytest.mark.parametrize("av_msg,status_code,expected_msg", [(["Found"], 400, ["Virus Found"]), (["Ok"], 200, [])])
-async def test_expected_failure_for_virus_found(virus_check, av_msg, status_code, expected_msg, get_default_mock_file):
+async def test_expected_failure_for_virus_found(virus_check,get_accepted_file_type_config, av_msg, status_code, expected_msg, get_default_mock_file):
     virus_check.return_value = av_msg,status_code
 
     test_header = {'content-length': 1235}
-
+    get_accepted_file_type_config.return_value = AcceptedFileTypes(acceptedExtensions=["png", "txt"],
+                                                                   acceptedContentTypes=["image/png", "text/plain"])
     result = await validate_request(test_header, get_default_mock_file)
     assert result.status_code == status_code and result.message == expected_msg
 
 @pytest.mark.asyncio
-async def test_expected_fail_for_incorrect_extension(get_default_mock_file):
+@patch("validation.validator.get_accepted_file_type_config")
+async def test_expected_fail_for_incorrect_extension(get_accepted_file_type_config,get_default_mock_file):
     get_default_mock_file.filename = 'test.invalid'
 
     test_header = {'content-length': 1235}
+    get_accepted_file_type_config.return_value = AcceptedFileTypes(acceptedExtensions=["png", "txt"],
+                                                                   acceptedContentTypes=["image/png", "text/plain"])
 
     result = await validate_request(test_header, get_default_mock_file)
 
     assert result.status_code == 415 and result.message == ["File extension is not PDF, DOC or TXT"]
 
 @pytest.mark.asyncio
-async def test_expected_fail_for_incorrect_content_type(get_default_mock_file):
+@patch("validation.validator.get_accepted_file_type_config")
+async def test_expected_fail_for_incorrect_content_type(get_accepted_file_type_config,get_default_mock_file):
     get_default_mock_file.content_type = 'invalid/type'
 
     test_header = {'content-length': 1235}
+    get_accepted_file_type_config.return_value = AcceptedFileTypes(acceptedExtensions=["png", "txt"],
+                                      acceptedContentTypes=["image/png", "text/plain"])
 
     result = await validate_request(test_header, get_default_mock_file)
 


### PR DESCRIPTION
As part of the vconfiguration options we want to have a dynamc setup where we pull the provider configuration from dynamo db.  This is only a spike of this and does not involve a full fledged configuration.  The things that are not covered here is how clietns will get this configurationito dynamo db.  Nor is this spike a solution to the configuration problem, we may look at other options for storing configuration depending on what is convenient. One of the alternatives is to use param store in AWS.


## Link to Jira Ticket

- [SDS-22](https://dsdmoj.atlassian.net/browse/SDS-22)

## Screenshots or test evidence if applicable

<!-- Any evidence of change working -->

[SDS-22]: https://dsdmoj.atlassian.net/browse/SDS-22?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ