### PR TITLE
Adding clam av to the infrastructure

### DIFF
--- a/deployments/kubernetes/service.yml
+++ b/deployments/kubernetes/service.yml
@@ -1,11 +1,22 @@
+---
 apiVersion: v1
 kind: Service
 metadata:
   name: laa-sds-service
 spec:
   selector:
-    app: laa-sds-api # this should match the pod label in deployment.yml
+    app: laa-sds-api
   ports:
     - name: https
       port: 8000
       targetPort: 8000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: laa-sds-clamav-service
+spec:
+  selector:
+    app: laa-sds-clamav
+  ports:
+    - port: 3310

--- a/deployments/kubernetes/stateful.yml
+++ b/deployments/kubernetes/stateful.yml
@@ -1,0 +1,48 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: laa-sds-clamav
+  labels:
+    app: laa-sds-clamav
+spec:
+  serviceName: "laa-sds-clamav-service"
+  replicas: 1
+  selector:
+    matchLabels:
+      app: laa-sds-clamav
+  template:
+    metadata:
+      labels:
+        app: laa-sds-clamav
+    spec:
+      securityContext:
+        fsGroup: 1000
+        runAsUser: 1000
+        runAsGroup: 1000
+      containers:
+        - name: laa-sds-clamav
+          image: ghcr.io/ministryofjustice/clamav-docker/laa-clamav:latest
+          imagePullPolicy: Always
+          volumeMounts:
+            - name: laa-sds-clamav-data
+              mountPath: "/var/lib/clamav"
+          resources:
+            requests:
+              memory: "4Gi"
+            limits:
+              memory: "5Gi"
+          ports:
+            - containerPort: 3310
+          env:
+            - name: FRESHCLAM_CHECKS
+              value: "24"
+            - name: MIRROR_URL
+              value: "https://laa-clamav-mirror-production.apps.live.cloud-platform.service.justice.gov.uk"
+  volumeClaimTemplates:
+  - metadata:
+      name: laa-sds-clamav-data
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 10Gi


### PR DESCRIPTION
## Description of change

Clam AV  pod will be used internally to run virus scans on files. 

Nb. This is only adding the pod integration will be done separately

## Link to Jira Ticket

- [SDS-61](https://dsdmoj.atlassian.net/browse/SDS-61)

## Screenshots or test evidence if applicable

<!-- Any evidence of change working -->

[SDS-61]: https://dsdmoj.atlassian.net/browse/SDS-61?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ