### PR TITLE
Fix issue with postman pipeline

### DIFF
--- a/.github/workflows/postman-tests.yml
+++ b/.github/workflows/postman-tests.yml
@@ -30,11 +30,6 @@ jobs:
       - name: Install LocalStack CLI
         run: pip install localstack
 
-      - name: Install AWS CLI
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y awscli
-
       - name: Setup AWS Credentials Directory
         run: mkdir -p ~/.aws
 


### PR DESCRIPTION
## Description of change

Removed step installing awscli.
awscli tools are now pre-installed on the github runner, and are no longer available via apt.

## Screenshots or test evidence if applicable

Change already tested on SDS-59
