### PR TITLE
Refactor to raise HTTPExceptions at the point the issue is encountered.

### DIFF
--- a/Postman/SecureDocStoreAPI.postman_collection.json
+++ b/Postman/SecureDocStoreAPI.postman_collection.json
@@ -68,6 +68,67 @@
 			"response": []
 		},
 		{
+			"name": "sds-client-token-invalid",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"let jsonData = pm.response.json();",
+							"pm.environment.set(\"bearerTokenInvalid\", jsonData.access_token);"
+						],
+						"type": "text/javascript",
+						"packages": {}
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "urlencoded",
+					"urlencoded": [
+						{
+							"key": "grant_type",
+							"value": "client_credentials",
+							"type": "text"
+						},
+						{
+							"key": "client_id",
+							"value": "{{client_id}}",
+							"type": "text"
+						},
+						{
+							"key": "client_secret",
+							"value": "{{client_secret}}",
+							"type": "text"
+						},
+						{
+							"key": "scope",
+							"value": "api://laa-sds-dev/.default",
+							"type": "text"
+						}
+					]
+				},
+				"url": {
+					"raw": "https://login.microsoftonline.com/c6874728-71e6-41fe-a9e1-2e8c36776ad8/oauth2/v2.0/token",
+					"protocol": "https",
+					"host": [
+						"login",
+						"microsoftonline",
+						"com"
+					],
+					"path": [
+						"c6874728-71e6-41fe-a9e1-2e8c36776ad8",
+						"oauth2",
+						"v2.0",
+						"token"
+					]
+				}
+			},
+			"response": []
+		},
+		{
 			"name": "Retrieve File",
 			"event": [
 				{
@@ -113,6 +174,77 @@
 					{
 						"key": "Authorization",
 						"value": "bearer {{bearerToken}}",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "http://127.0.0.1:8000/retrieve_file?file_key=README.md",
+					"protocol": "http",
+					"host": [
+						"127",
+						"0",
+						"0",
+						"1"
+					],
+					"port": "8000",
+					"path": [
+						"retrieve_file"
+					],
+					"query": [
+						{
+							"key": "file_key",
+							"value": "README.md"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Invalid scope token",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"// Test invalid scope token",
+							"pm.test(\"response code is 401\", function() {",
+							"    pm.response.to.have.status(401);",
+							"});"
+						],
+						"type": "text/javascript",
+						"packages": {}
+					}
+				}
+			],
+			"protocolProfileBehavior": {
+				"disableBodyPruning": true
+			},
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "",
+							"type": "string"
+						}
+					]
+				},
+				"method": "GET",
+				"header": [
+					{
+						"key": "Authorization",
+						"value": "bearer {{bearerTokenInvalid}}",
 						"type": "text"
 					}
 				],

--- a/src/main.py
+++ b/src/main.py
@@ -8,12 +8,12 @@ from asgi_correlation_id.context import correlation_id
 from fastapi import FastAPI
 from sentry_sdk.integrations.fastapi import FastApiIntegration
 from sentry_sdk.integrations.starlette import StarletteIntegration
-from starlette.middleware.authentication import AuthenticationMiddleware
+
 from structlog.stdlib import LoggerFactory
 from fastapi_authz import CasbinMiddleware
 
 from src.config import logging_config
-from src.middleware.auth import BearerTokenAuthBackend
+from src.middleware.auth import BearerTokenAuthBackend, BearerTokenMiddleware
 from src.routers import health as health_router
 from src.routers import retrieve_file as retrieve_router
 from src.routers import save_file as save_router
@@ -66,7 +66,8 @@ structlog.configure(
 logging.config.dictConfig(logging_config.config)
 # Order matters here: Casbin middleware first, then the auth backend
 app.add_middleware(CasbinMiddleware, enforcer=AuthzService().enforcer)
-app.add_middleware(AuthenticationMiddleware, backend=BearerTokenAuthBackend())
+app.add_middleware(BearerTokenMiddleware, backend=BearerTokenAuthBackend())
+
 app.include_router(health_router.router)
 app.include_router(retrieve_router.router)
 app.include_router(save_router.router)

--- a/src/middleware/auth.py
+++ b/src/middleware/auth.py
@@ -7,11 +7,30 @@ from fastapi import HTTPException
 from fastapi.security import HTTPBearer
 from fastapi.security.utils import get_authorization_scheme_param
 from jose import jwt, jwk, JWTError
-from starlette.authentication import AuthenticationBackend, SimpleUser, AuthCredentials, BaseUser
+from starlette.authentication import AuthenticationBackend, SimpleUser, AuthCredentials, BaseUser, AuthenticationError
+from starlette.middleware.authentication import AuthenticationMiddleware
 from starlette.requests import HTTPConnection
+from starlette.responses import PlainTextResponse, Response
 
 security = HTTPBearer()
 logger = structlog.get_logger()
+
+
+class DetailedAuthenticationError(AuthenticationError):
+    def __init__(self, status_code: int, detail: str) -> None:
+        self.status_code = status_code
+        self.detail = detail
+
+    def __str__(self) -> str:
+        return f"{self.status_code} {self.detail}"
+
+
+class BearerTokenMiddleware(AuthenticationMiddleware):
+    @staticmethod
+    def default_on_error(conn: HTTPConnection, exc: Exception) -> Response:
+        if isinstance(exc, AuthenticationError) and hasattr(exc, "status_code"):
+            return PlainTextResponse(str(exc), status_code=exc.status_code)
+        return PlainTextResponse(str(exc), status_code=401)
 
 
 class BearerTokenAuthBackend(AuthenticationBackend):
@@ -24,7 +43,7 @@ class BearerTokenAuthBackend(AuthenticationBackend):
         scheme, param = get_authorization_scheme_param(authorization)
         if scheme.lower() != "bearer":
             logger.info(f'Incorrect authorisation scheme {scheme}')
-            raise HTTPException(status_code=401, detail="Incorrect authorisation scheme")
+            raise DetailedAuthenticationError(status_code=401, detail="Incorrect authorisation scheme")
 
         payload = validate_token(param, os.getenv('AUDIENCE'), os.getenv('TENANT_ID'))
         username: str = payload.get("azp")
@@ -61,12 +80,9 @@ def validate_token(token: str, aud: str, tenant_id: str) -> dict:
             rsa_key_data = key
             break
 
-    is_valid = False
-    payload = {}
-
     if not rsa_key_data:
         logger.error(f"No rsa key found")
-        raise HTTPException(status_code=401, detail="Invalid or expired token")
+        raise DetailedAuthenticationError(status_code=401, detail="Invalid or expired token")
 
     try:
         rsa_key = jwk.construct(rsa_key_data, 'RS256')
@@ -79,16 +95,16 @@ def validate_token(token: str, aud: str, tenant_id: str) -> dict:
         )
     except Exception as error:
         logger.error(f"The token is invalid: {error.__class__.__name__} {error}")
-        raise HTTPException(status_code=401, detail="Invalid or expired token")
+        raise DetailedAuthenticationError(status_code=401, detail="Invalid or expired token")
 
     # Ensure token has `azp` claim which is used to identify the client
     if payload.get('azp') is None:
         logger.error(f"No verified azp claim. Verified claims {payload.keys()}")
-        raise HTTPException(status_code=403, detail="Not authenticated")
+        raise DetailedAuthenticationError(status_code=403, detail="Not authenticated")
 
     roles = payload.get('roles', [])
     if 'LAA_SDS.ALL' not in roles and 'SDS.READ' not in roles:
         logger.error(f"Token validates, but is missing required LAA_SDS.ALL or SDS.READ roles. Got {roles}")
-        raise HTTPException(status_code=403, detail="Not authenticated")
+        raise DetailedAuthenticationError(status_code=403, detail="Not authenticated")
 
     return payload

--- a/src/middleware/auth.py
+++ b/src/middleware/auth.py
@@ -18,23 +18,15 @@ class BearerTokenAuthBackend(AuthenticationBackend):
     async def authenticate(self, conn: HTTPConnection) -> tuple[AuthCredentials, BaseUser] | None:
         if "Authorization" not in conn.headers:
             logger.info('No auth headers')
-            return
-        try:
-            authorization: str = conn.headers.get("Authorization")
-            scheme, param = get_authorization_scheme_param(authorization)
-            if scheme.lower() != "bearer":
-                logger.info(f'Incorrect authorisation scheme {scheme}')
-                raise HTTPException(status_code=403, detail="Not authenticated")
+            return None
 
-            is_valid, payload = validate_token(param, os.getenv('AUDIENCE'), os.getenv('TENANT_ID'))
-        except JWTError as e:
-            logger.error(f"Invalid JWT token: {str(e)}")
-            raise HTTPException(status_code=401, detail="Invalid or expired token")
-        except Exception as e:
-            logger.error(f"Error processing bearer token: {str(e)}")
-            raise HTTPException(status_code=403, detail="Not authenticated")
-        if not is_valid:
-            raise HTTPException(status_code=403, detail="Not authenticated")
+        authorization: str = conn.headers.get("Authorization")
+        scheme, param = get_authorization_scheme_param(authorization)
+        if scheme.lower() != "bearer":
+            logger.info(f'Incorrect authorisation scheme {scheme}')
+            raise HTTPException(status_code=401, detail="Incorrect authorisation scheme")
+
+        payload = validate_token(param, os.getenv('AUDIENCE'), os.getenv('TENANT_ID'))
         username: str = payload.get("azp")
         auth_creds = AuthCredentials(scopes=[])
         user = SimpleUser(username)
@@ -52,7 +44,7 @@ def fetch_jwks(jwks_uri):
     return requests.get(jwks_uri).json()
 
 
-def validate_token(token: str, aud: str, tenant_id: str) -> Tuple[bool, dict]:
+def validate_token(token: str, aud: str, tenant_id: str) -> dict:
 
     # Fetch the OpenID configuration to get the JWK URI
     oidc_config = fetch_oidc_config(tenant_id)
@@ -72,34 +64,31 @@ def validate_token(token: str, aud: str, tenant_id: str) -> Tuple[bool, dict]:
     is_valid = False
     payload = {}
 
-    if rsa_key_data:
-        try:
-            rsa_key = jwk.construct(rsa_key_data, 'RS256')
-            payload = jwt.decode(
-                token,
-                rsa_key.to_dict(),
-                algorithms=['RS256'],
-                audience=aud,
-                issuer=f"https://login.microsoftonline.com/{tenant_id}/v2.0"
-            )
-            roles = payload.get('roles', [])
-            if 'LAA_SDS.ALL' in roles or 'SDS.READ' in roles:
-                is_valid = True
-            else:
-                logger.error(f"Token validates, but is missing required LAA_SDS.ALL or SDS.READ roles. Got {roles}")
-                is_valid = False
+    if not rsa_key_data:
+        logger.error(f"No rsa key found")
+        raise HTTPException(status_code=401, detail="Invalid or expired token")
 
-        except Exception as error:
-            logger.error(f"The token is invalid: {error.__class__.__name__} {error}")
+    try:
+        rsa_key = jwk.construct(rsa_key_data, 'RS256')
+        payload = jwt.decode(
+            token,
+            rsa_key.to_dict(),
+            algorithms=['RS256'],
+            audience=aud,
+            issuer=f"https://login.microsoftonline.com/{tenant_id}/v2.0"
+        )
+    except Exception as error:
+        logger.error(f"The token is invalid: {error.__class__.__name__} {error}")
+        raise HTTPException(status_code=401, detail="Invalid or expired token")
 
-            token_aud = jwt.get_unverified_claims(token).get('aud')
-            if token_aud != aud:
-                logger.error(f"The token audience does not match the expected audience: {token_aud} != {aud}")
+    # Ensure token has `azp` claim which is used to identify the client
+    if payload.get('azp') is None:
+        logger.error(f"No verified azp claim. Verified claims {payload.keys()}")
+        raise HTTPException(status_code=403, detail="Not authenticated")
 
-        # We use the azp claim as the client username
-        if payload.get('azp') is None:
-            unverified_claims = jwt.get_unverified_claims(token).keys()
-            logger.error(f"No azp claim. Verified claims {payload.keys()}, Unverified claims {unverified_claims}")
-            is_valid = False
+    roles = payload.get('roles', [])
+    if 'LAA_SDS.ALL' not in roles and 'SDS.READ' not in roles:
+        logger.error(f"Token validates, but is missing required LAA_SDS.ALL or SDS.READ roles. Got {roles}")
+        raise HTTPException(status_code=403, detail="Not authenticated")
 
-    return is_valid, payload
+    return payload

--- a/src/middleware/auth.py
+++ b/src/middleware/auth.py
@@ -98,11 +98,11 @@ def validate_token(token: str, aud: str, tenant_id: str) -> dict:
     # Ensure token has `azp` claim which is used to identify the client
     if payload.get('azp') is None:
         logger.error(f"No verified azp claim. Verified claims {payload.keys()}")
-        raise _AuthenticationError(status_code=403, detail="Not authenticated")
+        raise _AuthenticationError(status_code=403, detail="Forbidden")
 
     roles = payload.get('roles', [])
     if 'LAA_SDS.ALL' not in roles and 'SDS.READ' not in roles:
         logger.error(f"Token validates, but is missing required LAA_SDS.ALL or SDS.READ roles. Got {roles}")
-        raise _AuthenticationError(status_code=403, detail="Not authenticated")
+        raise _AuthenticationError(status_code=403, detail="Forbidden")
 
     return payload

--- a/src/middleware/auth.py
+++ b/src/middleware/auth.py
@@ -8,7 +8,7 @@ from jose import jwt, jwk
 from starlette.authentication import AuthenticationBackend, SimpleUser, AuthCredentials, BaseUser, AuthenticationError
 from starlette.middleware.authentication import AuthenticationMiddleware
 from starlette.requests import HTTPConnection
-from starlette.responses import PlainTextResponse, Response
+from starlette.responses import Response, JSONResponse
 
 security = HTTPBearer()
 logger = structlog.get_logger()
@@ -26,9 +26,9 @@ class _AuthenticationError(AuthenticationError):
 class BearerTokenMiddleware(AuthenticationMiddleware):
     @staticmethod
     def default_on_error(conn: HTTPConnection, exc: Exception) -> Response:
-        if hasattr(exc, "status_code"):
-            return PlainTextResponse(str(exc), status_code=exc.status_code)
-        return PlainTextResponse(str(exc), status_code=401)
+        if hasattr(exc, "status_code") and hasattr(exc, "detail"):
+            return JSONResponse({"detail": str(exc.detail)}, status_code=exc.status_code)
+        return JSONResponse({"detail": str(exc)}, status_code=401)
 
 
 class BearerTokenAuthBackend(AuthenticationBackend):

--- a/src/middleware/auth.py
+++ b/src/middleware/auth.py
@@ -1,12 +1,10 @@
 import os
-from typing import Tuple
 import requests
 import structlog
 from cachetools import cached, TTLCache
-from fastapi import HTTPException
 from fastapi.security import HTTPBearer
 from fastapi.security.utils import get_authorization_scheme_param
-from jose import jwt, jwk, JWTError
+from jose import jwt, jwk
 from starlette.authentication import AuthenticationBackend, SimpleUser, AuthCredentials, BaseUser, AuthenticationError
 from starlette.middleware.authentication import AuthenticationMiddleware
 from starlette.requests import HTTPConnection
@@ -81,7 +79,7 @@ def validate_token(token: str, aud: str, tenant_id: str) -> dict:
             break
 
     if not rsa_key_data:
-        logger.error(f"No rsa key found")
+        logger.error("No rsa key found")
         raise DetailedAuthenticationError(status_code=401, detail="Invalid or expired token")
 
     try:

--- a/src/routers/retrieve_file.py
+++ b/src/routers/retrieve_file.py
@@ -26,7 +26,7 @@ async def retrieve_file(
         logger.info("calling retrieve file operation")
         response = s3_service.retrieve_file_url(client_config, file_key)
         if response is None:
-            logger.error(f"Error whilst retrieving file from S3, got None response")
+            logger.error("Error whilst retrieving file from S3, got None response")
             raise FileNotFoundException(
                 f"File not found for client {client_config.azure_client_id}", file_key
             )

--- a/src/routers/retrieve_file.py
+++ b/src/routers/retrieve_file.py
@@ -33,4 +33,4 @@ async def retrieve_file(
         raise HTTPException(status_code=404, detail=str(e))
     except Exception as e:
         logger.error(f"Error retrieving file: {e.__class__.__name__} {str(e)}")
-        raise HTTPException(status_code=500, detail='An error occurred while retrieving the file')
+        raise HTTPException(status_code=599, detail='An error occurred while retrieving the file')

--- a/src/routers/retrieve_file.py
+++ b/src/routers/retrieve_file.py
@@ -33,4 +33,4 @@ async def retrieve_file(
         raise HTTPException(status_code=404, detail=str(e))
     except Exception as e:
         logger.error(f"Error retrieving file: {e.__class__.__name__} {str(e)}")
-        raise HTTPException(status_code=599, detail='An error occurred while retrieving the file')
+        raise HTTPException(status_code=500, detail='An error occurred while retrieving the file')

--- a/src/routers/retrieve_file.py
+++ b/src/routers/retrieve_file.py
@@ -25,8 +25,8 @@ async def retrieve_file(
 
         logger.info("calling retrieve file operation")
         response = s3_service.retrieve_file_url(client_config, file_key)
-        if response is None or response.status_code != 200:
-            logger.error(f"Error whilst retrieving file from S3: {response}")
+        if response is None:
+            logger.error(f"Error whilst retrieving file from S3, got None response")
             raise FileNotFoundException(
                 f"File not found for client {client_config.azure_client_id}", file_key
             )

--- a/src/routers/retrieve_file.py
+++ b/src/routers/retrieve_file.py
@@ -25,6 +25,11 @@ async def retrieve_file(
 
         logger.info("calling retrieve file operation")
         response = s3_service.retrieve_file_url(client_config, file_key)
+        if response is None or response.status_code != 200:
+            logger.error(f"Error whilst retrieving file from S3: {response}")
+            raise FileNotFoundException(
+                f"File not found for client {client_config.azure_client_id}", file_key
+            )
 
         logger.info(f"file retrieved successfully: {response}")
         return {'fileURL': response}

--- a/tests/middleware/test_auth.py
+++ b/tests/middleware/test_auth.py
@@ -15,6 +15,7 @@ class FakeKey:
     def to_dict(self):
         return {'key': 'value'}
 
+
 MOCK_OIDC_CONFIG = {'jwks_uri': 'mock_uri'}
 MOCK_JWKS = {'keys': [{'kid': 'mock_value'}, ]}
 MOCK_HEADER = MOCK_JWKS['keys'][0]
@@ -39,7 +40,9 @@ def test_missing_azp_claim(oidc_mock, jwks_mock, unv_header_mock, key_construct_
     unv_header_mock.return_value = MOCK_HEADER
     key_construct_mock.return_value = MOCK_KEY
 
-    decode_mock.return_value = {'sub': 'test_user', 'iss': 'https://login.microsoftonline.com/123456'}
+    decode_mock.return_value = {
+        'sub': 'test_user', 'iss': 'https://login.microsoftonline.com/123456'
+    }
 
     response = test_client.get('/retrieve_file?file_key=README.md', headers={'Authorization': 'Bearer token'})
     decode_mock.assert_called_once()
@@ -73,14 +76,18 @@ def test_incorrect_roles(oidc_mock, jwks_mock, unv_header_mock, key_construct_mo
 @patch('src.middleware.auth.jwt.get_unverified_header')
 @patch('src.middleware.auth.fetch_jwks')
 @patch('src.middleware.auth.fetch_oidc_config')
-def test_token_decode_expired_signature(oidc_mock, jwks_mock, unv_header_mock, key_construct_mock, decode_mock, audit_service_mock):
+def test_token_decode_expired_signature(
+            oidc_mock, jwks_mock, unv_header_mock, key_construct_mock, decode_mock, audit_service_mock
+        ):
     oidc_mock.return_value = MOCK_OIDC_CONFIG
     jwks_mock.return_value = MOCK_JWKS
     unv_header_mock.return_value = MOCK_HEADER
     key_construct_mock.return_value = MOCK_KEY
 
     decode_mock.side_effect = jwt.ExpiredSignatureError()
-    decode_mock.return_value = {'sub': 'test_user', 'iss': 'https://login.microsoftonline.com/123456', 'azp': 'test_user'}
+    decode_mock.return_value = {
+        'sub': 'test_user', 'iss': 'https://login.microsoftonline.com/123456', 'azp': 'test_user'
+    }
 
     response = test_client.get('/retrieve_file?file_key=README.md', headers={'Authorization': 'Bearer token'})
     decode_mock.assert_called_once()
@@ -93,14 +100,18 @@ def test_token_decode_expired_signature(oidc_mock, jwks_mock, unv_header_mock, k
 @patch('src.middleware.auth.jwt.get_unverified_header')
 @patch('src.middleware.auth.fetch_jwks')
 @patch('src.middleware.auth.fetch_oidc_config')
-def test_token_decode_jwterror(oidc_mock, jwks_mock, unv_header_mock, key_construct_mock, decode_mock, audit_service_mock):
+def test_token_decode_jwterror(
+            oidc_mock, jwks_mock, unv_header_mock, key_construct_mock, decode_mock, audit_service_mock
+        ):
     oidc_mock.return_value = MOCK_OIDC_CONFIG
     jwks_mock.return_value = MOCK_JWKS
     unv_header_mock.return_value = MOCK_HEADER
     key_construct_mock.return_value = MOCK_KEY
 
     decode_mock.side_effect = JWTError()
-    decode_mock.return_value = {'sub': 'test_user', 'iss': 'https://login.microsoftonline.com/123456', 'azp': 'test_user'}
+    decode_mock.return_value = {
+        'sub': 'test_user', 'iss': 'https://login.microsoftonline.com/123456', 'azp': 'test_user'
+    }
 
     response = test_client.get('/retrieve_file?file_key=README.md', headers={'Authorization': 'Bearer token'})
     decode_mock.assert_called_once()
@@ -113,14 +124,18 @@ def test_token_decode_jwterror(oidc_mock, jwks_mock, unv_header_mock, key_constr
 @patch('src.middleware.auth.jwt.get_unverified_header')
 @patch('src.middleware.auth.fetch_jwks')
 @patch('src.middleware.auth.fetch_oidc_config')
-def test_token_decode_jwtclaimserror(oidc_mock, jwks_mock, unv_header_mock, key_construct_mock, decode_mock, audit_service_mock):
+def test_token_decode_jwtclaimserror(
+            oidc_mock, jwks_mock, unv_header_mock, key_construct_mock, decode_mock, audit_service_mock
+        ):
     oidc_mock.return_value = MOCK_OIDC_CONFIG
     jwks_mock.return_value = MOCK_JWKS
     unv_header_mock.return_value = MOCK_HEADER
     key_construct_mock.return_value = MOCK_KEY
 
     decode_mock.side_effect = JWTClaimsError()
-    decode_mock.return_value = {'sub': 'test_user', 'iss': 'https://login.microsoftonline.com/123456', 'azp': 'test_user'}
+    decode_mock.return_value = {
+        'sub': 'test_user', 'iss': 'https://login.microsoftonline.com/123456', 'azp': 'test_user'
+    }
 
     response = test_client.get('/retrieve_file?file_key=README.md', headers={'Authorization': 'Bearer token'})
     decode_mock.assert_called_once()
@@ -138,7 +153,9 @@ def test_jwks_uri_invalid(oidc_mock, unv_header_mock, key_construct_mock, decode
     unv_header_mock.return_value = MOCK_HEADER
     key_construct_mock.return_value = MOCK_KEY
 
-    decode_mock.return_value = {'sub': 'test_user', 'iss': 'https://login.microsoftonline.com/123456', 'azp': 'test_user'}
+    decode_mock.return_value = {
+        'sub': 'test_user', 'iss': 'https://login.microsoftonline.com/123456', 'azp': 'test_user'
+    }
 
     response = test_client.get('/retrieve_file?file_key=README.md', headers={'Authorization': 'Bearer token'})
     decode_mock.assert_not_called()
@@ -158,7 +175,9 @@ def test_rsa_key_missing(oidc_mock, jwks_mock, unv_header_mock, key_construct_mo
     unv_header_mock.return_value = {'kid': 'incorrect_value'}
     key_construct_mock.return_value = MOCK_KEY
 
-    decode_mock.return_value = {'sub': 'test_user', 'iss': 'https://login.microsoftonline.com/123456', 'azp': 'test_user'}
+    decode_mock.return_value = {
+        'sub': 'test_user', 'iss': 'https://login.microsoftonline.com/123456', 'azp': 'test_user'
+    }
 
     response = test_client.get('/retrieve_file?file_key=README.md', headers={'Authorization': 'Bearer token'})
     decode_mock.assert_not_called()

--- a/tests/middleware/test_auth.py
+++ b/tests/middleware/test_auth.py
@@ -1,0 +1,165 @@
+from unittest.mock import patch
+import pytest
+import structlog
+from fastapi.testclient import TestClient
+from jose import jwt, JWTError
+from jose.exceptions import JWTClaimsError
+
+from src.main import app
+
+test_client = TestClient(app)
+logger = structlog.get_logger()
+
+
+class FakeKey:
+    def to_dict(self):
+        return {'key': 'value'}
+
+MOCK_OIDC_CONFIG = {'jwks_uri': 'mock_uri'}
+MOCK_JWKS = {'keys': [{'kid': 'mock_value'}, ]}
+MOCK_HEADER = MOCK_JWKS['keys'][0]
+MOCK_KEY = FakeKey()
+
+
+@pytest.mark.normal_auth
+def test_incorrect_auth_scheme(audit_service_mock):
+    response = test_client.get('/retrieve_file?file_key=README.md', headers={'Authorization': 'Notbearer token'})
+    assert response.status_code == 401
+
+
+@pytest.mark.normal_auth
+@patch('src.middleware.auth.jwt.decode')
+@patch('src.middleware.auth.jwk.construct')
+@patch('src.middleware.auth.jwt.get_unverified_header')
+@patch('src.middleware.auth.fetch_jwks')
+@patch('src.middleware.auth.fetch_oidc_config')
+def test_missing_azp_claim(oidc_mock, jwks_mock, unv_header_mock, key_construct_mock, decode_mock, audit_service_mock):
+    oidc_mock.return_value = MOCK_OIDC_CONFIG
+    jwks_mock.return_value = MOCK_JWKS
+    unv_header_mock.return_value = MOCK_HEADER
+    key_construct_mock.return_value = MOCK_KEY
+
+    decode_mock.return_value = {'sub': 'test_user', 'iss': 'https://login.microsoftonline.com/123456'}
+
+    response = test_client.get('/retrieve_file?file_key=README.md', headers={'Authorization': 'Bearer token'})
+    decode_mock.assert_called_once()
+    assert response.status_code == 403
+
+
+@pytest.mark.normal_auth
+@patch('src.middleware.auth.jwt.decode')
+@patch('src.middleware.auth.jwk.construct')
+@patch('src.middleware.auth.jwt.get_unverified_header')
+@patch('src.middleware.auth.fetch_jwks')
+@patch('src.middleware.auth.fetch_oidc_config')
+def test_incorrect_roles(oidc_mock, jwks_mock, unv_header_mock, key_construct_mock, decode_mock, audit_service_mock):
+    oidc_mock.return_value = MOCK_OIDC_CONFIG
+    jwks_mock.return_value = MOCK_JWKS
+    unv_header_mock.return_value = MOCK_HEADER
+    key_construct_mock.return_value = MOCK_KEY
+
+    decode_mock.return_value = {
+        'sub': 'test_user', 'iss': 'https://login.microsoftonline.com/123456', 'azp': 'test_user', 'roles': ['MISS', ]
+    }
+
+    response = test_client.get('/retrieve_file?file_key=README.md', headers={'Authorization': 'Bearer token'})
+    decode_mock.assert_called_once()
+    assert response.status_code == 403
+
+
+@pytest.mark.normal_auth
+@patch('src.middleware.auth.jwt.decode')
+@patch('src.middleware.auth.jwk.construct')
+@patch('src.middleware.auth.jwt.get_unverified_header')
+@patch('src.middleware.auth.fetch_jwks')
+@patch('src.middleware.auth.fetch_oidc_config')
+def test_token_decode_expired_signature(oidc_mock, jwks_mock, unv_header_mock, key_construct_mock, decode_mock, audit_service_mock):
+    oidc_mock.return_value = MOCK_OIDC_CONFIG
+    jwks_mock.return_value = MOCK_JWKS
+    unv_header_mock.return_value = MOCK_HEADER
+    key_construct_mock.return_value = MOCK_KEY
+
+    decode_mock.side_effect = jwt.ExpiredSignatureError()
+    decode_mock.return_value = {'sub': 'test_user', 'iss': 'https://login.microsoftonline.com/123456', 'azp': 'test_user'}
+
+    response = test_client.get('/retrieve_file?file_key=README.md', headers={'Authorization': 'Bearer token'})
+    decode_mock.assert_called_once()
+    assert response.status_code == 401
+
+
+@pytest.mark.normal_auth
+@patch('src.middleware.auth.jwt.decode')
+@patch('src.middleware.auth.jwk.construct')
+@patch('src.middleware.auth.jwt.get_unverified_header')
+@patch('src.middleware.auth.fetch_jwks')
+@patch('src.middleware.auth.fetch_oidc_config')
+def test_token_decode_jwterror(oidc_mock, jwks_mock, unv_header_mock, key_construct_mock, decode_mock, audit_service_mock):
+    oidc_mock.return_value = MOCK_OIDC_CONFIG
+    jwks_mock.return_value = MOCK_JWKS
+    unv_header_mock.return_value = MOCK_HEADER
+    key_construct_mock.return_value = MOCK_KEY
+
+    decode_mock.side_effect = JWTError()
+    decode_mock.return_value = {'sub': 'test_user', 'iss': 'https://login.microsoftonline.com/123456', 'azp': 'test_user'}
+
+    response = test_client.get('/retrieve_file?file_key=README.md', headers={'Authorization': 'Bearer token'})
+    decode_mock.assert_called_once()
+    assert response.status_code == 401
+
+
+@pytest.mark.normal_auth
+@patch('src.middleware.auth.jwt.decode')
+@patch('src.middleware.auth.jwk.construct')
+@patch('src.middleware.auth.jwt.get_unverified_header')
+@patch('src.middleware.auth.fetch_jwks')
+@patch('src.middleware.auth.fetch_oidc_config')
+def test_token_decode_jwtclaimserror(oidc_mock, jwks_mock, unv_header_mock, key_construct_mock, decode_mock, audit_service_mock):
+    oidc_mock.return_value = MOCK_OIDC_CONFIG
+    jwks_mock.return_value = MOCK_JWKS
+    unv_header_mock.return_value = MOCK_HEADER
+    key_construct_mock.return_value = MOCK_KEY
+
+    decode_mock.side_effect = JWTClaimsError()
+    decode_mock.return_value = {'sub': 'test_user', 'iss': 'https://login.microsoftonline.com/123456', 'azp': 'test_user'}
+
+    response = test_client.get('/retrieve_file?file_key=README.md', headers={'Authorization': 'Bearer token'})
+    decode_mock.assert_called_once()
+    assert response.status_code == 401
+
+
+@pytest.mark.normal_auth
+@patch('src.middleware.auth.jwt.decode')
+@patch('src.middleware.auth.jwk.construct')
+@patch('src.middleware.auth.jwt.get_unverified_header')
+@patch('src.middleware.auth.fetch_oidc_config')
+def test_jwks_uri_invalid(oidc_mock, unv_header_mock, key_construct_mock, decode_mock, audit_service_mock):
+    # Tests the processing chain when the jwks_uri is not found or malformed
+    oidc_mock.return_value = {'jwks_uri': 'mock_uri'}
+    unv_header_mock.return_value = MOCK_HEADER
+    key_construct_mock.return_value = MOCK_KEY
+
+    decode_mock.return_value = {'sub': 'test_user', 'iss': 'https://login.microsoftonline.com/123456', 'azp': 'test_user'}
+
+    response = test_client.get('/retrieve_file?file_key=README.md', headers={'Authorization': 'Bearer token'})
+    decode_mock.assert_not_called()
+
+    assert response.status_code == 401
+
+
+@pytest.mark.normal_auth
+@patch('src.middleware.auth.jwt.decode')
+@patch('src.middleware.auth.jwk.construct')
+@patch('src.middleware.auth.jwt.get_unverified_header')
+@patch('src.middleware.auth.fetch_jwks')
+@patch('src.middleware.auth.fetch_oidc_config')
+def test_rsa_key_missing(oidc_mock, jwks_mock, unv_header_mock, key_construct_mock, decode_mock, audit_service_mock):
+    oidc_mock.return_value = MOCK_OIDC_CONFIG
+    jwks_mock.return_value = MOCK_JWKS
+    unv_header_mock.return_value = {'kid': 'incorrect_value'}
+    key_construct_mock.return_value = MOCK_KEY
+
+    decode_mock.return_value = {'sub': 'test_user', 'iss': 'https://login.microsoftonline.com/123456', 'azp': 'test_user'}
+
+    response = test_client.get('/retrieve_file?file_key=README.md', headers={'Authorization': 'Bearer token'})
+    decode_mock.assert_not_called()
+    assert response.status_code == 401


### PR DESCRIPTION
## Description of change

Sometimes a client will see a 500 error instead of the coded 403 or 401.
This patch aims to raise exceptions at the point the issue is encountered rather than waiting, and ensure the correct status code is returned to the client. We also catch additional token processing issues.

Added a Postman test with an invalid scope to verify token error code is correctly returned to the client.

Added unit tests for the auth middleware to verify the claims and processing are handled correctly.
