### PR TITLE
Sds 120/fix zero byte save

### DIFF
--- a/src/handlers/file_upload_handler.py
+++ b/src/handlers/file_upload_handler.py
@@ -25,7 +25,7 @@ async def handle_file_upload_logic(
     file_contents = await file.read()
     
     # Antivirus scan
-    validation_result = await clam_av_validator.scan_request(request.headers, file)
+    validation_result = await clam_av_validator.scan_request(request.headers, file, file_contents)
     if validation_result.status_code != 200:
         raise HTTPException(
             status_code=validation_result.status_code,

--- a/src/handlers/file_upload_handler.py
+++ b/src/handlers/file_upload_handler.py
@@ -20,6 +20,10 @@ async def handle_file_upload_logic(
     client_config: ClientConfig,
     request_type: RequestType,
 ) -> Tuple[Dict, bool]:
+    
+    # Read contents of file. Only works once - get nothing if try a second time.  
+    file_contents = await file.read()
+    
     # Antivirus scan
     validation_result = await clam_av_validator.scan_request(request.headers, file)
     if validation_result.status_code != 200:

--- a/src/handlers/file_upload_handler.py
+++ b/src/handlers/file_upload_handler.py
@@ -68,7 +68,7 @@ async def handle_file_upload_logic(
             OperationType.CREATE
         )
 
-        success = s3_service.save(client_config, file.file, full_filename, metadata)
+        success = s3_service.save(client_config, file_contents, full_filename, metadata)
         if not success:
             raise HTTPException(
                 status_code=500,

--- a/src/services/s3_service.py
+++ b/src/services/s3_service.py
@@ -86,7 +86,7 @@ class S3Service:
         except Exception as e:
             logger.debug(f"{e.__class__.__name__} reading file from S3: {str(e)}")
 
-    def upload_file_obj(self, file: BytesIO, filename: str, metadata: dict | None = None):
+    def upload_file_obj(self, file_contents: bytes, filename: str, metadata: dict | None = None):
         if metadata is None:
             metadata = {}
         logger.debug(f"Uploading file with name {filename} to S3 bucket {self.client_config.bucket_name}")
@@ -94,7 +94,7 @@ class S3Service:
             self.s3_client.put_object(
                 Bucket=self.client_config.bucket_name,
                 Key=filename,
-                Body=file.read(),
+                Body=file_contents,
                 Metadata=metadata
             )
         except Exception as e:
@@ -128,11 +128,11 @@ def retrieve_file_url(client: str | ClientConfig, file_name: str):
     return s3_service.generate_file_url(file_name)
 
 
-def save(client: str | ClientConfig, file: BytesIO, file_name: str, metadata: dict | None = None) -> bool:
+def save(client: str | ClientConfig, file_contents: bytes, file_name: str, metadata: dict | None = None) -> bool:
     if metadata is None:
         metadata = {}
 
     s3_service = S3Service.get_instance(client)
-    s3_service.upload_file_obj(file, file_name, metadata)
+    s3_service.upload_file_obj(file_contents, file_name, metadata)
 
     return True

--- a/tests/handlers/test_file_upload_handler.py
+++ b/tests/handlers/test_file_upload_handler.py
@@ -1,5 +1,5 @@
 from io import BytesIO
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, AsyncMock
 import pytest
 from fastapi import HTTPException
 
@@ -43,7 +43,7 @@ async def test_handle_file_upload_success(
     expected_success_message,
 ):
     request = MagicMock(headers={})
-    file = MagicMock()
+    file = AsyncMock()
     file.filename = "test_file.txt"
     file.file = BytesIO(b"Test content")
     body = MagicMock()
@@ -84,7 +84,7 @@ async def test_handle_file_upload_POST_existing_file_failure(
     scan_request_mock
 ):
     request = MagicMock(headers={})
-    file = MagicMock()
+    file = AsyncMock()
     file.filename = "preexisting_test_file.txt"
     file.file = BytesIO(b"Test content")
     body = MagicMock()
@@ -116,7 +116,7 @@ async def test_handle_file_upload_antivirus_failure(scan_request_mock):
     scan_request_mock.return_value = ValidationResponse(status_code=400, message="Virus detected")
 
     request = MagicMock(headers={})
-    file = MagicMock()
+    file = AsyncMock()
     file.filename = "infected_file.txt"
     file.file = BytesIO(b"Bad content")
 
@@ -158,7 +158,7 @@ async def test_handle_file_upload_save_failure(
     scan_request_mock.return_value = ValidationResponse(status_code=200, message="")
 
     request = MagicMock(headers={})
-    file = MagicMock()
+    file = AsyncMock()
     file.filename = "test_file.txt"
     file.file = BytesIO(b"Test content")
 

--- a/tests/services/test_s3_service.py
+++ b/tests/services/test_s3_service.py
@@ -75,19 +75,19 @@ def test_upload_file_obj_success(s3_service, mocker):
     # Arrange
     mock_put_object = mocker.patch.object(s3_service.s3_client, 'put_object')
 
-    file = BytesIO(b"Test data")
+    file_contents = b"Test data"
     bucket_name = 'test_bucket'
     filename = 'test_file'
     metadata = {'key1': 'value1'}
 
     # Act
-    s3_service.upload_file_obj(file, filename, metadata)
+    s3_service.upload_file_obj(file_contents, filename, metadata)
 
     # Assert
     mock_put_object.assert_called_once_with(
         Bucket=bucket_name,
         Key=filename,
-        Body=file.getvalue(),
+        Body=file_contents,
         Metadata=metadata
     )
 


### PR DESCRIPTION
## Description of change

Changed the way file data is read. Before it was read by both the av scan and the S3 bucket save. However, on the second read no data is returned, so empty file was written to the bucket.

### Summary of changes:

#### Original Plan
1. Update `handle_file_upload_logic` function so that reading the file content now takes place here, and before any av scan or S3 saving takes place.
2. Change `clam_av_validator.scan_request` to receive the file contents as a parameter instead of reading the data itself.
3. Change `s3_service.save` to receive the file contents as a parameter instead of reading the data itself.

_Problem_
`clam_av_validator.scan_request` actually does 3 things: (iii)check file has content-length (ii) check file exists, (ii) do av_scan. This means "check file exists" is too late in the original plan as we'd need to do this before we read the file!

#### Revised Plan ####
1. Change  `clam_av_validator.scan_request` to also have responsibility for reading the file and returning its data. It was originally reading the file anyway but just keeping the data for itself, so we just change it to return both the validation result and the file data (if succssfully read).
2. Change `handle_file_upload_logic` to accept the returned file data from `clam_av_validator.scan_request`
3. (same as original plan) Change `s3_service.save` to receive the file contents as a parameter instead of reading the data itself.

#### Potential changes

- Rename `upload_file_obj` function as it's no longer receives a file object, so something like `upload_file_data` might now be a more fitting name.
- Fix the return value from `s3_service.save` which is currently hard-coded to `True`. Out of scope but might be good to do in passing anyway.

#### Some things not changed but potentially could be changed in future
A couple of further potential improvements but these could be complicated, so would be better covered separately from the current change.

- Could the way we're supplying the file data to the av scan could be improved? We're taking an UploadFile object, reading data from it, then making a Bytes.IO file-like object from this data for the av scan itself. Are all these transformations necessary? (The present change hasn't altered this, just changed things so we're only reading the data once).


## Link to Jira Ticket

- [SDS-120](https://dsdmoj.atlassian.net/browse/SDS-120)

## Screenshots or test evidence if applicable

<!-- Any evidence of change working -->

[SDS-120]: https://dsdmoj.atlassian.net/browse/SDS-120?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ