### PR TITLE
Fix 0-byte save issue in SDS (verified commit version)

### DIFF
--- a/src/validation/clam_av_validator.py
+++ b/src/validation/clam_av_validator.py
@@ -46,6 +46,8 @@ def check_file_exists(headers: Header, file: UploadFile):
 async def check_antivirus(headers: Header, file: UploadFile):
     file_content = await file.read()
     response, status = await virus_check(io.BytesIO(file_content))
+    # Return file reference point to start to make subsequent read possible
+    await file.seek(0)
     if status == 200:
         return 200, ""
     else:

--- a/tests/validation_tests/test_clam_av_validator.py
+++ b/tests/validation_tests/test_clam_av_validator.py
@@ -32,3 +32,16 @@ async def test_expected_failure_for_virus_found(virus_check, av_msg, status_code
 
     result = await scan_request(test_header, get_default_mock_file)
     assert result.status_code == status_code and result.message == expected_msg
+
+
+@pytest.mark.asyncio
+@patch("src.validation.clam_av_validator.virus_check")
+async def test_expected_pass_for_good_file(mock_virus_check, get_default_mock_file):
+    mock_virus_check.return_value = "Ok", 200
+    test_header = {'content-length': 1235}
+    result = await scan_request(test_header, get_default_mock_file)
+    file_calls = [str(c) for c in get_default_mock_file.mock_calls]
+    assert result.status_code == 200
+    assert file_calls == ["call.read()", "call.seek(0)"]
+    # Line below not currently useful as the mock always returns this value
+    assert await get_default_mock_file.read() == b'test_file_content'


### PR DESCRIPTION
## Description of change
Note this is a replacement for PR https://github.com/ministryofjustice/laa-secure-document-storage-api/pull/225 which was approved but could not be merged because its commits were unsigned. This has the same changes but with a verified commit. It's also built on a more recent version of main.

#### The Problem
Uploads to S3 were only saving zero-byte files because the av scan was reading the file contents first, which left the data unavailable for reading when later uploading to S3.

#### The Fix
Updated `clam_av_validator.check_antivirus` to reset the file reference using `file.seek(0)` after reading the file. This means the file contents remain available when `S3Service.upload_file_obj` subsequently reads the file when saving to S3.

Also added new `scan_request` test to check the file reference reset has taken place. This new test is currently limited by the way the existing mock file object works, as its read method  doesn't replicate the behaviour of an UploadFile object in this circumstance. Could be improved in a future update.

## Link to Jira Ticket

- [SDS-120](https://dsdmoj.atlassian.net/browse/SDS-120)


## Screenshots or test evidence if applicable
The delete file postman tests are failing for me locally but the others are passing. Although they're passing in the automated github action run below.

<!-- Any evidence of change working -->

[SDS-120]: https://dsdmoj.atlassian.net/browse/SDS-120?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ