### PR TITLE
SDS-91: S3 Delete Logic

### DIFF
--- a/Postman/SecureDocStoreAPI.postman_collection.json
+++ b/Postman/SecureDocStoreAPI.postman_collection.json
@@ -1615,7 +1615,7 @@
 									"pm.test(\"Response body shows success\", function() {",
 									"    var responseBody = pm.response.json();",
 									"    pm.expect(responseBody).to.be.an('object');",
-									"    pm.expect(responseBody).to.have.property('success', 'File saved successfully in ' + pm.environment.get('SDSBucket') + ' with key ' + pm.environment.get('unique_filename_a'));",
+									"    pm.expect(responseBody).to.have.property('success', 'File saved successfully in ' + pm.environment.get('SDSBucket') + ' with key ' + pm.variables.get('unique_filename_a'));",
 									"});"
 								],
 								"type": "text/javascript",
@@ -1695,7 +1695,7 @@
 									"pm.test(\"Response body shows success\", function() {",
 									"    var responseBody = pm.response.json();",
 									"    pm.expect(responseBody).to.be.an('object');",
-									"    pm.expect(responseBody).to.have.property('success', 'File saved successfully in ' + pm.environment.get('SDSBucket') + ' with key ' + pm.environment.get('unique_filename_b'));",
+									"    pm.expect(responseBody).to.have.property('success', 'File saved successfully in ' + pm.environment.get('SDSBucket') + ' with key ' + pm.variables.get('unique_filename_b'));",
 									"});"
 								],
 								"type": "text/javascript",
@@ -1775,7 +1775,7 @@
 									"pm.test(\"Response body shows success\", function() {",
 									"    var responseBody = pm.response.json();",
 									"    pm.expect(responseBody).to.be.an('object');",
-									"    pm.expect(responseBody).to.have.property('success', 'File saved successfully in ' + pm.environment.get('SDSBucket') + ' with key ' + pm.environment.get('unique_filename_c'));",
+									"    pm.expect(responseBody).to.have.property('success', 'File saved successfully in ' + pm.environment.get('SDSBucket') + ' with key ' + pm.variables.get('unique_filename_c'));",
 									"});"
 								],
 								"type": "text/javascript",
@@ -1855,7 +1855,7 @@
 									"pm.test(\"Response body shows success\", function() {",
 									"    var responseBody = pm.response.json();",
 									"    pm.expect(responseBody).to.be.an('object');",
-									"    pm.expect(responseBody).to.have.property('success', 'File saved successfully in ' + pm.environment.get('SDSBucket') + ' with key ' + pm.environment.get('unique_filename_d'));",
+									"    pm.expect(responseBody).to.have.property('success', 'File saved successfully in ' + pm.environment.get('SDSBucket') + ' with key ' + pm.variables.get('unique_filename_d'));",
 									"});"
 								],
 								"type": "text/javascript",
@@ -1935,12 +1935,12 @@
 									"",
 									"pm.test(\"response contains filename key\", function() {",
 									"    const responseBody = pm.response.json();",
-									"    pm.expect(responseBody).to.have.property(pm.environment.get('unique_filename_a'));",
+									"    pm.expect(responseBody).to.have.property(pm.variables.get('unique_filename_a'));",
 									"});",
 									"",
 									"pm.test(\"response contains expected deletion status for file\", function() {",
 									"    const responseBody = pm.response.json();",
-									"    //pm.expect(responseBody[pm.environment.get('unique_filename_a')]).to.equal(204);",
+									"    pm.expect(responseBody[pm.variables.get('unique_filename_a')]).to.equal(204);",
 									"});",
 									""
 								],
@@ -2217,12 +2217,12 @@
 									"",
 									"pm.test(\"Response contains filename key\", function() {",
 									"    const responseBody = pm.response.json();",
-									"    pm.expect(responseBody).to.have.property(pm.environment.get('non_existent_file'));",
+									"    pm.expect(responseBody).to.have.property(pm.variables.get('non_existent_file'));",
 									"});",
 									"",
 									"pm.test(\"Outcome code for file is 404 - FILE NOT FOUND\", function() {",
 									"    const responseBody = pm.response.json();",
-									"    //pm.expect(responseBody[pm.environment.get('non_existent_file')]).to.equal(404);",
+									"    pm.expect(responseBody[pm.variables.get('non_existent_file')]).to.equal(404);",
 									"});",
 									""
 								],
@@ -2302,7 +2302,7 @@
 									"pm.test(\"Response body shows file not found\", function() {",
 									"    var responseBody = pm.response.json();",
 									"    pm.expect(responseBody).to.be.an('object');",
-									"    pm.expect(responseBody).to.have.property('detail', 'The file '+pm.environment.get('unique_filename_a')+' could not be found.');",
+									"    pm.expect(responseBody).to.have.property('detail', 'The file '+pm.variables.get('unique_filename_a')+' could not be found.');",
 									"});",
 									""
 								],
@@ -2378,7 +2378,6 @@
 							"listen": "test",
 							"script": {
 								"exec": [
-									"/*",
 									"pm.test(\"Status code is SUCCESS\", function () {",
 									"    pm.response.to.have.status(200);",
 									"});",
@@ -2387,7 +2386,7 @@
 									"    const responseBody = pm.response.json();",
 									"    pm.expect(responseBody).to.have.property('fileURL').that.is.a('string');",
 									"});",
-									"*/"
+									""
 								],
 								"type": "text/javascript",
 								"packages": {}
@@ -2468,22 +2467,22 @@
 									"",
 									"pm.test(\"response contains filename key\", function() {",
 									"    const responseBody = pm.response.json();",
-									"    pm.expect(responseBody).to.have.property(pm.environment.get('unique_filename_b'));",
+									"    pm.expect(responseBody).to.have.property(pm.variables.get('unique_filename_b'));",
 									"});",
 									"",
 									"pm.test(\"response contains expected deletion status for file\", function() {",
 									"    const responseBody = pm.response.json();",
-									"    pm.expect(responseBody[pm.environment.get('unique_filename_b')]).to.equal(204);",
+									"    pm.expect(responseBody[pm.variables.get('unique_filename_b')]).to.equal(204);",
 									"});",
 									"",
 									"pm.test(\"response contains filename key\", function() {",
 									"    const responseBody = pm.response.json();",
-									"    pm.expect(responseBody).to.have.property(pm.environment.get('unique_filename_c'));",
+									"    pm.expect(responseBody).to.have.property(pm.variables.get('unique_filename_c'));",
 									"});",
 									"",
 									"pm.test(\"response contains expected deletion status for file\", function() {",
 									"    const responseBody = pm.response.json();",
-									"    pm.expect(responseBody[pm.environment.get('unique_filename_c')]).to.equal(204);",
+									"    pm.expect(responseBody[pm.variables.get('unique_filename_c')]).to.equal(204);",
 									"});",
 									""
 								],
@@ -2562,19 +2561,15 @@
 						"type": "text/javascript",
 						"packages": {},
 						"exec": [
-							"const timestamp = new Date().getTime();",
-							"const uniqueFilenameA = `test_file_${timestamp}_a.md`;",
-							"const uniqueFilenameB = `test_file_${timestamp}_b.md`;",
-							"const uniqueFilenameC = `test_file_${timestamp}_c.md`;",
-							"const uniqueFilenameD = `test_file_${timestamp}_d.md`;",
-							"const nonExistentFile = `non_existent_file.md`;",
-			
-							"",
-							"pm.environment.set(\"unique_filename_a\", uniqueFilenameA);",
-							"pm.environment.set(\"unique_filename_b\", uniqueFilenameB);",
-							"pm.environment.set(\"unique_filename_c\", uniqueFilenameC);",
-							"pm.environment.set(\"unique_filename_d\", uniqueFilenameD);",
-							"pm.environment.set(\"non_existent_file\", nonExistentFile);",
+							"// Scope vars to the run",
+							"if ( ! pm.variables.has(\"unique_filename_a\") ) {",
+							"    const timestamp = new Date().getTime();",
+							"    pm.variables.set(\"unique_filename_a\", `test_file_${timestamp}_a.md`);",
+							"    pm.variables.set(\"unique_filename_b\", `test_file_${timestamp}_b.md`);",
+							"    pm.variables.set(\"unique_filename_c\", `test_file_${timestamp}_c.md`);",
+							"    pm.variables.set(\"unique_filename_d\", `test_file_${timestamp}_d.md`);",
+							"    pm.variables.set(\"non_existent_file\", `non_existent_file_${timestamp}.md`);",
+							"}",
 							""
 						]
 					}

--- a/Postman/SecureDocStoreAPI.postman_collection.json
+++ b/Postman/SecureDocStoreAPI.postman_collection.json
@@ -1842,6 +1842,86 @@
 					"response": []
 				},
 				{
+					"name": "Save D File For Deleting",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is CREATED\", function () {",
+									"    pm.response.to.have.status(201);",
+									"});",
+									"",
+									"pm.test(\"Response body shows success\", function() {",
+									"    var responseBody = pm.response.json();",
+									"    pm.expect(responseBody).to.be.an('object');",
+									"    pm.expect(responseBody).to.have.property('success', 'File saved successfully in ' + pm.environment.get('SDSBucket') + ' with key ' + pm.environment.get('unique_filename_d'));",
+									"});"
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									""
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "bearer {{bearerToken}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "formdata",
+							"formdata": [
+								{
+									"key": "body",
+									"value": "{\"bucketName\": \"{{SDSBucket}}\"}",
+									"type": "text"
+								},
+								{
+									"key": "file",
+									"type": "file",
+									"src": "test_file.md",
+									"fileName": "{{unique_filename_d}}"
+								}
+							]
+						},
+						"url": {
+							"raw": "{{SDSBaseUrl}}/save_file",
+							"host": [
+								"{{SDSBaseUrl}}"
+							],
+							"path": [
+								"save_file"
+							]
+						},
+						"description": "Expect a 201 OK when saving a new file."
+					},
+					"response": []
+				},
+				{
 					"name": "Delete Single File",
 					"event": [
 						{
@@ -1927,13 +2007,294 @@
 					"response": []
 				},
 				{
+					"name": "Delete Single File - No File Key Provided",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"",
+									"pm.test(\"Status code is 400 - BAD REQUEST\", function() {",
+									"    pm.response.to.have.status(400);",
+									"});",
+									"",
+									"pm.test(\"Request must include at least one filename\", function () {",
+									"    var responseBody = pm.response.json();",
+									"    pm.expect(responseBody).to.have.property('detail');",
+									"    pm.expect(responseBody.detail).to.include('File key is missing');",
+									"});"
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									""
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "",
+									"type": "string"
+								}
+							]
+						},
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "bearer {{bearerToken}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{SDSBaseUrl}}/delete_files?file_keys={}",
+							"host": [
+								"{{SDSBaseUrl}}"
+							],
+							"path": [
+								"delete_files"
+							],
+							"query": [
+							]
+						},
+						"description": "Expect a 400 BAD REQUEST when no filename(s) are provided for deletion"
+					},
+					"response": []
+				},
+				{
+					"name": "Delete Single File Without Authorisation",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"",
+									"pm.test(\"Status code is 403 - FORBIDDEN\", function() {",
+									"    pm.response.to.have.status(403);",
+									"});",
+									"",
+									"pm.test(\"Response message is not authorised\", function() {",
+									"    var responseBody = pm.response.json();",
+									"    pm.expect(responseBody).to.be.an('object');",
+									"    pm.expect(responseBody).to.have.property('detail', 'Forbidden');",
+									"});"
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									"// Sets token without necessary scope to delete before test runs",
+									"",
+									"function postRequest(secret) {",
+									"    const postRequest = {",
+									"        url: tokenUrl,",
+									"        method: 'POST',",
+									"        header: {",
+									"            'Content-Type': 'application/x-www-form-urlencoded'",
+									"        },",
+									"        body: {",
+									"            mode: 'urlencoded',",
+									"            urlencoded:",
+									"                [",
+									"                    { key: 'grant_type', value: 'client_credentials' },",
+									"                    { key: 'client_id', value: clientId },",
+									"                    { key: 'client_secret', value: secret },",
+									"                    { key: 'scope', value: scope }",
+									"                ]",
+									"        }",
+									"    };",
+									"",
+									"    pm.sendRequest(postRequest, (error, response) => {",
+									"        let jsonData = response.json()",
+									"        pm.variables.set(\"bearerToken\", jsonData.access_token)",
+									"    })",
+									"}",
+									"",
+									"// resolve variables from the environment",
+									"const tokenUrl = pm.environment.get('AzureTokenUrl')",
+									"const clientId = pm.environment.get('SDSClientID')",
+									"const scope = pm.environment.get('InvalidScope')",
+									"var envSecret = pm.environment.get('SDSClientSecret')",
+									"",
+									"// locally resolve secret from vault, in pipeline use env var\",",
+									"if (envSecret.startsWith('{{vault:')) {",
+									"    secretKey = envSecret.replace('{{vault:', '').replace('}}', '')",
+									"    // use .then() in place of await to support newman runner",
+									"    pm.vault.get(secretKey).then(vaultValue => postRequest(vaultValue))",
+									"}",
+									"else {",
+									"    postRequest(envSecret)",
+									"}"
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "",
+									"type": "string"
+								}
+							]
+						},
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "bearer {{bearerToken}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{SDSBaseUrl}}/delete_files?file_keys={unique_filename_d}",
+							"host": [
+								"{{SDSBaseUrl}}"
+							],
+							"path": [
+								"delete_files"
+							],
+							"query": [
+								{
+									"key": "file_keys",
+									"value": "{{unique_filename_d}}"
+								}
+							]
+						},
+						"description": "Expect a 403 FORBIDDEN outcome when user does not hold the required permissions to delete files"
+					},
+					"response": []
+				},
+				{
+					"name": "Delete Non-Existent File",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"",
+									"pm.test(\"Overall status code is 202 - ACCEPTED \", function() {",
+									"    pm.response.to.have.status(202);",
+									"});",
+									"",
+									"pm.test(\"Response contains filename key\", function() {",
+									"    const responseBody = pm.response.json();",
+									"    pm.expect(responseBody).to.have.property(pm.environment.get('non_existent_file'));",
+									"});",
+									"",
+									"pm.test(\"Outcome code for file is 404 - FILE NOT FOUND\", function() {",
+									"    const responseBody = pm.response.json();",
+									"    //pm.expect(responseBody[pm.environment.get('non_existent_file')]).to.equal(404);",
+									"});",
+									""
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									""
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "",
+									"type": "string"
+								}
+							]
+						},
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "bearer {{bearerToken}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{SDSBaseUrl}}/delete_files?file_keys={{non_existent_file}}",
+							"host": [
+								"{{SDSBaseUrl}}"
+							],
+							"path": [
+								"delete_files"
+							],
+							"query": [
+								{
+									"key": "file_keys",
+									"value": "{{non_existent_file}}"
+								}
+							]
+						},
+						"description": "Expect a 404 NOT FOUND outcome when trying to delete a file that cannot be found in specified bucket"
+					},
+					"response": []
+				},
+				{
 					"name": "Retrieve Deleted File",
 					"event": [
 						{
 							"listen": "test",
 							"script": {
 								"exec": [
-									"/*",
 									"pm.test(\"Status code is NOT FOUND\", function () {",
 									"    pm.response.to.have.status(404);",
 									"});",
@@ -1943,7 +2304,6 @@
 									"    pm.expect(responseBody).to.be.an('object');",
 									"    pm.expect(responseBody).to.have.property('detail', 'The file '+pm.environment.get('unique_filename_a')+' could not be found.');",
 									"});",
-									"*/",
 									""
 								],
 								"type": "text/javascript",
@@ -2113,7 +2473,7 @@
 									"",
 									"pm.test(\"response contains expected deletion status for file\", function() {",
 									"    const responseBody = pm.response.json();",
-									"    //pm.expect(responseBody[pm.environment.get('unique_filename_b')]).to.equal(204);",
+									"    pm.expect(responseBody[pm.environment.get('unique_filename_b')]).to.equal(204);",
 									"});",
 									"",
 									"pm.test(\"response contains filename key\", function() {",
@@ -2123,7 +2483,7 @@
 									"",
 									"pm.test(\"response contains expected deletion status for file\", function() {",
 									"    const responseBody = pm.response.json();",
-									"    //pm.expect(responseBody[pm.environment.get('unique_filename_c')]).to.equal(204);",
+									"    pm.expect(responseBody[pm.environment.get('unique_filename_c')]).to.equal(204);",
 									"});",
 									""
 								],
@@ -2206,10 +2566,15 @@
 							"const uniqueFilenameA = `test_file_${timestamp}_a.md`;",
 							"const uniqueFilenameB = `test_file_${timestamp}_b.md`;",
 							"const uniqueFilenameC = `test_file_${timestamp}_c.md`;",
+							"const uniqueFilenameD = `test_file_${timestamp}_d.md`;",
+							"const nonExistentFile = `non_existent_file.md`;",
+			
 							"",
 							"pm.environment.set(\"unique_filename_a\", uniqueFilenameA);",
 							"pm.environment.set(\"unique_filename_b\", uniqueFilenameB);",
 							"pm.environment.set(\"unique_filename_c\", uniqueFilenameC);",
+							"pm.environment.set(\"unique_filename_d\", uniqueFilenameD);",
+							"pm.environment.set(\"non_existent_file\", nonExistentFile);",
 							""
 						]
 					}
@@ -2230,7 +2595,7 @@
 			"name": "SDSVirusCheckFileTests",
 			"item": [
 				{
-					"name": "Check file with virus",
+					"name": "Check File With Virus",
 					"event": [
 						{
 							"listen": "test",
@@ -2306,7 +2671,7 @@
 					"response": []
 				},
 				{
-					"name": "Check file without virus",
+					"name": "Check File Without Virus",
 					"event": [
 						{
 							"listen": "prerequest",

--- a/src/routers/delete_files.py
+++ b/src/routers/delete_files.py
@@ -58,7 +58,6 @@ async def delete_files(
         except Exception as e:
             msg = f"Unexpected error deleting {file_key}: {e.__class__.__name__} - {str(e)}"
             logger.exception(msg)
-            outcomes[file_key] = 500 # SERVER ERROR
-
+            outcomes[file_key] = 500  # SERVER ERROR
 
     return JSONResponse(outcomes, status_code=202)  # ACCEPTED

--- a/src/routers/delete_files.py
+++ b/src/routers/delete_files.py
@@ -52,11 +52,19 @@ async def delete_files(
             # ...therefore this was a success
             outcomes[file_key] = 204  # NO CONTENT, delete was successful
 
+        except ValueError:
+            logger.error("File name not provided")
+            outcomes[file_key] = 400 # BAD REQUEST
+        except PermissionError:
+            logger.error(f"Access denied to delete {file_key}")
+            outcomes[file_key] = 403 # FORBIDDEN
         except FileNotFoundError:
             logger.error(f"File to be deleted {file_key} not found for client {client_config.azure_client_id}")
             outcomes[file_key] = 404  # NOT FOUND
         except Exception as e:
-            logger.error(f"Error deleting file: {e.__class__.__name__} {str(e)}")
-            outcomes[file_key] = 500  # SERVER ERROR
+            msg = f"Unexpected error deleting {file_key}: {e.__class__.__name__} - {str(e)}"
+            logger.exception(msg)
+            outcomes[file_key] = 500 # SERVER ERROR
+
 
     return JSONResponse(outcomes, status_code=202)  # ACCEPTED

--- a/src/routers/delete_files.py
+++ b/src/routers/delete_files.py
@@ -52,12 +52,6 @@ async def delete_files(
             # ...therefore this was a success
             outcomes[file_key] = 204  # NO CONTENT, delete was successful
 
-        except ValueError:
-            logger.error("File name not provided")
-            outcomes[file_key] = 400 # BAD REQUEST
-        except PermissionError:
-            logger.error(f"Access denied to delete {file_key}")
-            outcomes[file_key] = 403 # FORBIDDEN
         except FileNotFoundError:
             logger.error(f"File to be deleted {file_key} not found for client {client_config.azure_client_id}")
             outcomes[file_key] = 404  # NOT FOUND

--- a/src/services/s3_service.py
+++ b/src/services/s3_service.py
@@ -100,6 +100,25 @@ class S3Service:
         except Exception as e:
             logger.error(f"{e.__class__.__name__} uploading file to S3: {str(e)}")
             raise e
+    
+    def delete_file_obj(self, filename: str):
+    
+        try:
+            logger.debug(f"Attempting to delete file {filename} from S3 bucket {self.client_config.bucket_name}")
+            self.s3_client.delete_object(
+                Bucket=self.client_config.bucket_name,
+                Key=filename,
+            )
+            logger.info(f"File {filename} successfully deleted from bucket {self.client_config.bucket_name}")
+        except ClientError as e:
+            error_code = e.response.get("Error", {}).get("Code", "")
+            if error_code == "NoSuchKey":
+                logger.warning(f"File {filename} not found in bucket {self.client_config.bucket_name}")
+                raise FileNotFoundError(f"File {filename} not found in bucket {self.client_config.bucket_name}")
+            else:
+                logger.error(f"{e.__class__.__name__} deleting file from S3: {str(e)}")
+                raise
+
 
     def file_exists_in_bucket(self, key: str) -> bool:
         try:
@@ -139,13 +158,7 @@ def save(client: str | ClientConfig, file: BytesIO, file_name: str, metadata: di
 
 
 def delete_file(client: str | ClientConfig, file_name: str):
-    """
-    Deletes the specified file from the client's configured bucket.
-
-    :raises: FileNotFoundError if file does not exist.
-    :param client:
-    :param file_name:
-    :return:
-    """
-    logger.warning(f"Deleting file {file_name} NOT IMPLEMENTED")
-    raise NotImplementedError()
+    s3_service = S3Service.get_instance(client)
+    s3_service.delete_file_obj(file_name)
+    
+    return True

--- a/src/services/s3_service.py
+++ b/src/services/s3_service.py
@@ -159,6 +159,8 @@ def save(client: str | ClientConfig, file: BytesIO, file_name: str, metadata: di
 
 
 def delete_file(client: str | ClientConfig, file_name: str):
+    if not file_name:
+        raise ValueError("file_name must be provided")
     s3_service = S3Service.get_instance(client)
     s3_service.delete_file_obj(file_name)
     

--- a/src/services/s3_service.py
+++ b/src/services/s3_service.py
@@ -102,7 +102,6 @@ class S3Service:
             raise e
     
     def delete_file_obj(self, filename: str):
-    
         try:
             logger.debug(f"Attempting to delete file {filename} from S3 bucket {self.client_config.bucket_name}")
             self.s3_client.delete_object(
@@ -115,10 +114,12 @@ class S3Service:
             if error_code == "NoSuchKey":
                 logger.warning(f"File {filename} not found in bucket {self.client_config.bucket_name}")
                 raise FileNotFoundError(f"File {filename} not found in bucket {self.client_config.bucket_name}")
+            elif error_code in {"AccessDenied", "AllAccessDisabled"}:
+                logger.warning(f"Access denied trying to delete {filename} from bucket {self.client_config.bucket_name}")
+                raise PermissionError(f"Access denied to delete {filename}")
             else:
                 logger.error(f"{e.__class__.__name__} deleting file from S3: {str(e)}")
                 raise
-
 
     def file_exists_in_bucket(self, key: str) -> bool:
         try:

--- a/src/services/s3_service.py
+++ b/src/services/s3_service.py
@@ -104,6 +104,7 @@ class S3Service:
     def delete_file_obj(self, filename: str):
         try:
             logger.debug(f"Attempting to delete file {filename} from S3 bucket {self.client_config.bucket_name}")
+            self.s3_client.head_object(Bucket=self.client_config.bucket_name, Key=filename)
             self.s3_client.delete_object(
                 Bucket=self.client_config.bucket_name,
                 Key=filename,
@@ -111,7 +112,7 @@ class S3Service:
             logger.info(f"File {filename} successfully deleted from bucket {self.client_config.bucket_name}")
         except ClientError as e:
             error_code = e.response.get("Error", {}).get("Code", "")
-            if error_code == "NoSuchKey":
+            if error_code == "NoSuchKey" or error_code == "404":
                 logger.warning(f"File {filename} not found in bucket {self.client_config.bucket_name}")
                 raise FileNotFoundError(f"File {filename} not found in bucket {self.client_config.bucket_name}")
             else:

--- a/src/services/s3_service.py
+++ b/src/services/s3_service.py
@@ -100,7 +100,7 @@ class S3Service:
         except Exception as e:
             logger.error(f"{e.__class__.__name__} uploading file to S3: {str(e)}")
             raise e
-    
+
     def delete_file_obj(self, filename: str):
         try:
             logger.debug(f"Attempting to delete file {filename} from S3 bucket {self.client_config.bucket_name}")
@@ -158,5 +158,5 @@ def save(client: str | ClientConfig, file: BytesIO, file_name: str, metadata: di
 def delete_file(client: str | ClientConfig, file_name: str):
     s3_service = S3Service.get_instance(client)
     s3_service.delete_file_obj(file_name)
-    
+
     return True

--- a/src/services/s3_service.py
+++ b/src/services/s3_service.py
@@ -114,9 +114,6 @@ class S3Service:
             if error_code == "NoSuchKey":
                 logger.warning(f"File {filename} not found in bucket {self.client_config.bucket_name}")
                 raise FileNotFoundError(f"File {filename} not found in bucket {self.client_config.bucket_name}")
-            elif error_code in {"AccessDenied", "AllAccessDisabled"}:
-                logger.warning(f"Access denied trying to delete {filename} from bucket {self.client_config.bucket_name}")
-                raise PermissionError(f"Access denied to delete {filename}")
             else:
                 logger.error(f"{e.__class__.__name__} deleting file from S3: {str(e)}")
                 raise
@@ -159,8 +156,6 @@ def save(client: str | ClientConfig, file: BytesIO, file_name: str, metadata: di
 
 
 def delete_file(client: str | ClientConfig, file_name: str):
-    if not file_name:
-        raise ValueError("file_name must be provided")
     s3_service = S3Service.get_instance(client)
     s3_service.delete_file_obj(file_name)
     

--- a/tests/routers/test_delete_files.py
+++ b/tests/routers/test_delete_files.py
@@ -9,6 +9,7 @@ def test_delete_files_missing_key(test_client):
     assert 'detail' in response.json()
     assert response.json()['detail'] == 'File key is missing'
 
+
 @patch("src.services.authz_service.enforce_or_error")
 def test_delete_files_permission_denied(authz_mock, test_client):
     authz_mock.side_effect = HTTPException(status_code=403, detail="Forbidden")
@@ -17,6 +18,7 @@ def test_delete_files_permission_denied(authz_mock, test_client):
     response = test_client.delete(f'/delete_files?file_keys={file_key}')
 
     assert response.status_code == 403
+
 
 @patch("src.routers.delete_files.s3_service.delete_file")
 def test_delete_files_missing_file(s3_delete_mock, test_client, audit_service_mock):

--- a/tests/routers/test_delete_files.py
+++ b/tests/routers/test_delete_files.py
@@ -23,7 +23,7 @@ def test_delete_files_missing_file(s3_delete_mock, test_client, audit_service_mo
 
 @patch("src.routers.delete_files.s3_service.delete_file")
 def test_delete_files_unexpected_error(s3_delete_mock, test_client, audit_service_mock):
-    s3_delete_mock.side_effect = ValueError()
+    s3_delete_mock.side_effect = RuntimeError()
     file_key = 'test_file.md'
 
     response = test_client.delete(f'/delete_files?file_keys={file_key}')
@@ -64,7 +64,7 @@ def test_delete_files_multiple_status(s3_delete_mock, test_client, audit_service
     s3_delete_mock.side_effect = [
         True,
         FileNotFoundError(),
-        ValueError()
+        RuntimeError()
     ]
     file_a = 'file_a.md'
     file_b = 'file_b.md'

--- a/tests/routers/test_delete_files.py
+++ b/tests/routers/test_delete_files.py
@@ -8,6 +8,16 @@ def test_delete_files_missing_key(test_client):
     assert 'detail' in response.json()
     assert response.json()['detail'] == 'File key is missing'
 
+@patch("src.routers.delete_files.s3_service.delete_file")
+def test_delete_files_permission_denied(s3_delete_mock, test_client, audit_service_mock):
+    s3_delete_mock.side_effect = PermissionError()
+    file_key = 'test_file.md'
+
+    response = test_client.delete(f'/delete_files?file_keys={file_key}')
+
+    assert response.status_code == 202
+    assert file_key in response.json()
+    assert response.json()[file_key] == 403
 
 @patch("src.routers.delete_files.s3_service.delete_file")
 def test_delete_files_missing_file(s3_delete_mock, test_client, audit_service_mock):

--- a/tests/services/test_s3_service.py
+++ b/tests/services/test_s3_service.py
@@ -145,22 +145,6 @@ def test_delete_file_obj_file_not_found(s3_service, mocker):
     assert "not found" in str(exc_info.value).lower()
 
 
-def test_delete_file_obj_permission_denied(s3_service, mocker):
-    mocker.patch.object(
-        s3_service.s3_client,
-        'delete_object',
-        side_effect=ClientError(
-            error_response={"Error": {"Code": "AccessDenied", "Message": "Forbidden"}},
-            operation_name='DeleteObject'
-        )
-    )
-
-    with pytest.raises(PermissionError) as exc_info:
-        s3_service.delete_file_obj('private_file.md')
-
-    assert "access denied" in str(exc_info.value).lower()
-
-
 def test_delete_file_obj_unexpected_error(s3_service, mocker):
     mocker.patch.object(
         s3_service.s3_client,

--- a/tests/services/test_s3_service.py
+++ b/tests/services/test_s3_service.py
@@ -131,7 +131,7 @@ def test_delete_file_obj_success(s3_service, mocker):
 
 def test_delete_file_obj_file_not_found(s3_service, mocker):
     mocker.patch.object(
-        s3_service.s3_client, 
+        s3_service.s3_client,
         'delete_object',
         side_effect=ClientError(
             error_response={"Error": {"Code": "NoSuchKey", "Message": "Not Found"}},
@@ -156,4 +156,3 @@ def test_delete_file_obj_unexpected_error(s3_service, mocker):
         s3_service.delete_file_obj('any_file.md')
 
     assert "something went wrong" in str(exc_info.value).lower()
-

--- a/tests/services/test_s3_service.py
+++ b/tests/services/test_s3_service.py
@@ -148,6 +148,10 @@ def test_delete_file_obj_file_not_found(s3_service, mocker):
         s3_service.delete_file_obj('missing_file.md')
 
     assert "not found" in str(exc_info.value).lower()
+    mock_head_object.assert_called_once_with(
+        Bucket=s3_service.client_config.bucket_name,
+        Key='missing_file.md'
+    )
 
 
 def test_delete_file_obj_file_not_found_via_head(s3_service, mocker):
@@ -172,6 +176,10 @@ def test_delete_file_obj_file_not_found_via_head(s3_service, mocker):
         s3_service.delete_file_obj('missing_file.md')
 
     assert "not found" in str(exc_info.value).lower()
+    mock_head_object.assert_called_once_with(
+        Bucket=s3_service.client_config.bucket_name,
+        Key='missing_file.md'
+    )
 
 
 def test_delete_file_obj_unexpected_error(s3_service, mocker):
@@ -186,3 +194,7 @@ def test_delete_file_obj_unexpected_error(s3_service, mocker):
         s3_service.delete_file_obj('any_file.md')
 
     assert "something went wrong" in str(exc_info.value).lower()
+    mock_head_object.assert_called_once_with(
+        Bucket=s3_service.client_config.bucket_name,
+        Key='any_file.md'
+    )


### PR DESCRIPTION
## Description of change

Adds logic in our s3 service layer for the `delete_files` endpoint (ensuring status codes are passed up to endpoint level).
Unit tests and Postman tests have been added/updated accordingly.


If successful, a 200 204 (success, no content) success code is returned

If unsuccessful, we return:
- at router level
    - 400 bad request (e.g. no file specified)
    - 403 forbidden (e.g. incorrect permissions)
- at s3_service level (surfaced in the `outcomes` dict returned at the router level)
    - 404 file not found (e.g. file not found in specified bucket)
    - 500 generic error

## Link to Jira Ticket

- [SDS-91](https://dsdmoj.atlassian.net/browse/SDS-91)

## Screenshots or test evidence if applicable

![Screenshot 2025-05-27 at 18 47 47](https://github.com/user-attachments/assets/303b5301-44f7-4da2-8d53-aa4ec61b0b76)


[SDS-91]: https://dsdmoj.atlassian.net/browse/SDS-91?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ