### PR TITLE
SDS-116 Add Correlation IDss to logs

### DIFF
--- a/src/config/logging_config.py
+++ b/src/config/logging_config.py
@@ -2,15 +2,23 @@ import os
 config = {
     'version': 1,
     'disable_existing_loggers': False,
+    'filters': {
+        'correlation_id': {
+            '()': 'asgi_correlation_id.CorrelationIdFilter',
+            'uuid_length': 32,
+            'default_value': '-',
+            },
+        },
     'formatters': {
         'structFormatter': {
             'class': 'logging.Formatter',
-            'format': '%(message)s'
+            'format': '[%(correlation_id)s] %(message)s'
         }
     },
     'handlers': {
         'consoleHandler': {
             'class': 'logging.StreamHandler',
+            'filters': ['correlation_id'],
             'level': 'DEBUG',
             'formatter': 'structFormatter'
         }

--- a/src/config/logging_config.py
+++ b/src/config/logging_config.py
@@ -2,23 +2,15 @@ import os
 config = {
     'version': 1,
     'disable_existing_loggers': False,
-    'filters': {
-        'correlation_id': {
-            '()': 'asgi_correlation_id.CorrelationIdFilter',
-            'uuid_length': 32,
-            'default_value': '-',
-            },
-        },
     'formatters': {
         'structFormatter': {
             'class': 'logging.Formatter',
-            'format': '[%(correlation_id)s] %(message)s'
+            'format': '%(message)s'
         }
     },
     'handlers': {
         'consoleHandler': {
             'class': 'logging.StreamHandler',
-            'filters': ['correlation_id'],
             'level': 'DEBUG',
             'formatter': 'structFormatter'
         }


### PR DESCRIPTION
## Description of change

Fixed the correlation ID logging which wasn't working. It was almost right but needed `CorrelationIdMiddleware` adding to get it to work.

Also added new Correlation ID section to the end of the readme file.

## Bit of a test aside
I did toy with adding some related tests and thought a quick way of doing this would be to use the FastAPI test client. The ASGI correlation ID logging process relies on correlation IDs being added to response headers as `x-request-id`. Plan was to  make requests using the Fast API test client, then check that `x-request-id` is (a) present and (b) has a different value when you make a second request. However, when using the Fast API test client the `x-request-id` value simply isn't present in the headers, so this doesn't work.

In contrast `x-request-id` is present when using SDS for real, so potentially could use this in the Postman tests but seems too much hassle for a small change. Potentially Locust would be great for this as we could make lots of requests and check all the correlation IDs are unique.

I'd argue we can get away with not having correlation ID related tests as:
- We didn't have any before
- We're using a third party library with its standard example configuration, so low risk an not really our own work.

## Link to Jira Ticket

- [SDS-116](https://dsdmoj.atlassian.net/browse/SDS-116)

## Screenshots or test evidence if applicable
No new tests added - just demonstrating existing ones not broken!
![image](https://github.com/user-attachments/assets/18edaa7f-af40-4864-b17d-01ccc22678d6)

[SDS-116]: https://dsdmoj.atlassian.net/browse/SDS-116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ