### PR TITLE
Sds 164 extend pytest e2e coverage

### DIFF
--- a/tests/end_to_end/e2e_helpers.py
+++ b/tests/end_to_end/e2e_helpers.py
@@ -58,6 +58,13 @@ class UploadFileData:
         self.reset_seek()
         return self.file_details
 
+    def close_file(self):
+        """
+        Closing the file will prevent it from being used.
+        Only intended for test cleanup step.
+        """
+        self.file_details["file"][1].close()
+
 
 def get_mimetype(filename: str) -> str:
     mimetype = mimetypes.guess_type(filename)[0]

--- a/tests/end_to_end/test_e2e.py
+++ b/tests/end_to_end/test_e2e.py
@@ -36,6 +36,8 @@ token_getter = TokenManager(client_id=os.getenv('CLIENT_ID'),
                             )
 
 test_md_file = UploadFileData("Postman/test_file.md")
+virus_file = UploadFileData("Postman/eicar.txt")
+disallowed_file = UploadFileData("Postman/test_file.exe")
 
 
 @pytest.mark.e2e
@@ -49,6 +51,8 @@ def test_token_can_be_retrieved():
     response = client.post(token_url, data=params)
     assert response.status_code == 200
     assert "Error" not in response.text
+
+# Health and Status Tests
 
 
 @pytest.mark.e2e
@@ -93,12 +97,16 @@ def test_available_validators_returns_expected_response():
     assert response.status_code == 200
     assert bad_results == []
 
+# Docs Test
+
 
 @pytest.mark.e2e
 def test_swagger_doc_is_available():
     response = client.get(f"{HOST_URL}/docs")
     assert response.status_code == 200
     assert "LAA Secure Document Storage API - Swagger UI" in response.text
+
+# Auth Tests
 
 
 @pytest.mark.e2e
@@ -118,16 +126,7 @@ def test_retrieve_file_unsuccessful_if_invalid_token():
     assert response.status_code == 401
     assert "Invalid or expired token" in response.text
 
-
-@pytest.mark.e2e
-def test_get_file_is_successful():
-    params = {"file_key": "README.md"}
-    headers = token_getter.get_headers()
-    response = client.get(f"{HOST_URL}/retrieve_file", headers=headers, params=params)
-    assert response.status_code == 200
-    assert "fileURL" in response.text
-    assert "Expires" in response.text
-    assert params["file_key"] in response.text
+# Save or Update File Tests
 
 
 @pytest.mark.e2e
@@ -169,6 +168,196 @@ def test_put_new_file_twice_gives_expected_code_and_message():
     assert response1.status_code == 201 and str(response1.text).startswith('{"success":"File saved successfully')
     assert response2.status_code == 200 and str(response2.text).startswith('{"success":"File updated successfully')
 
+
+@pytest.mark.e2e
+def test_put_file_with_virus_is_blocked():
+    upload_bucket = '{"bucketName": "sds-local"}'
+    upload_virus_file = virus_file.get_data()
+    response = client.put(f"{HOST_URL}/save_or_update_file",
+                          headers=token_getter.get_headers(),
+                          files=upload_virus_file,
+                          data={"body": upload_bucket})
+    assert response.status_code == 400
+    assert response.json()["detail"] == ["Virus Found"]
+
+
+@pytest.mark.e2e
+def test_put_file_with_disallowed_file_type_is_blocked():
+    upload_bucket = '{"bucketName": "sds-local"}'
+    upload_disallowed_file = disallowed_file.get_data()
+    response = client.put(f"{HOST_URL}/save_or_update_file",
+                          headers=token_getter.get_headers(),
+                          files=upload_disallowed_file,
+                          data={"body": upload_bucket})
+    assert response.status_code == 415
+    assert response.json()["detail"] == "File mimetype not allowed"
+
+
+@pytest.mark.e2e
+def test_put_file_with_missing_bucket_is_blocked():
+    new_filename = make_unique_name("put_new_file_test.txt")
+    upload_file = test_md_file.get_data(new_filename)
+    # Care with formatting the below - value needs to be str, delimted with '
+    # (Although this is just creating a body that lacks bucketName)
+    data = {"body": '{"folder": "testmult"}'}
+    response = client.put(f"{HOST_URL}/save_or_update_file",
+                          headers=token_getter.get_headers(),
+                          files=upload_file,
+                          data=data)
+    assert response.status_code == 400
+    assert response.json()["detail"]["bucketName"] == "Field required"
+
+
+@pytest.mark.e2e
+def test_put_file_without_file_fails_as_expected():
+    upload_bucket = '{"bucketName": "sds-local"}'
+
+    response = client.put(f"{HOST_URL}/save_or_update_file",
+                          headers=token_getter.get_headers(),
+                          data={"body": upload_bucket})
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == ["File is required"]
+
+
+# Retrieve File Tests (Deprecated)
+
+
+@pytest.mark.e2e
+def test_retrieve_file_is_successful():
+    params = {"file_key": "README.md"}
+    headers = token_getter.get_headers()
+    response = client.get(f"{HOST_URL}/retrieve_file", headers=headers, params=params)
+    assert response.status_code == 200
+    assert "fileURL" in response.text
+    assert "Expires" in response.text
+    assert params["file_key"] in response.text
+
+
+@pytest.mark.e2e
+def test_retrieve_file_returns_expected_error_when_file_not_found():
+    params = {"file_key": "does-not-exist.txt"}
+    headers = token_getter.get_headers()
+    response = client.get(f"{HOST_URL}/retrieve_file", headers=headers, params=params)
+    assert response.status_code == 404
+    assert "The file does-not-exist.txt could not be found." in response.text
+
+# Get File Tests
+
+
+@pytest.mark.e2e
+def test_get_file_is_successful():
+    params = {"file_key": "README.md"}
+    headers = token_getter.get_headers()
+    response = client.get(f"{HOST_URL}/get_file", headers=headers, params=params)
+    assert response.status_code == 200
+    assert "fileURL" in response.text
+    assert "Expires" in response.text
+    assert params["file_key"] in response.text
+
+
+@pytest.mark.e2e
+def test_get_file_returns_expected_error_when_file_not_found():
+    params = {"file_key": "does-not-exist.txt"}
+    headers = token_getter.get_headers()
+    response = client.get(f"{HOST_URL}/get_file", headers=headers, params=params)
+    assert response.status_code == 404
+    assert "The file does-not-exist.txt could not be found." in response.text
+
+# Save File Tests
+
+
+@pytest.mark.e2e
+def test_post_new_file_once_is_successful():
+    upload_bucket = '{"bucketName": "sds-local"}'
+    new_filename = make_unique_name("post_new_file_test.txt")
+    upload_file = test_md_file.get_data(new_filename)
+
+    response = client.post(f"{HOST_URL}/save_file",
+                           headers=token_getter.get_headers(),
+                           files=upload_file,
+                           data={"body": upload_bucket})
+
+    assert response.status_code == 201
+    assert str(response.text).startswith('{"success":"File saved successfully')
+    assert str(response.text).endswith(f'with key {new_filename}"}}')
+
+
+@pytest.mark.e2e
+def test_post_new_file_second_time_fails():
+    upload_bucket = '{"bucketName": "sds-local"}'
+    new_filename = make_unique_name("post_new_file_test.txt")
+    upload_file = test_md_file.get_data(new_filename)
+
+    response1 = client.post(f"{HOST_URL}/save_file",
+                            headers=token_getter.get_headers(),
+                            files=upload_file,
+                            data={"body": upload_bucket})
+
+    response2 = client.post(f"{HOST_URL}/save_file",
+                            headers=token_getter.get_headers(),
+                            files=upload_file,
+                            data={"body": upload_bucket})
+
+    assert response1.status_code == 201
+    assert str(response1.text).startswith('{"success":"File saved successfully')
+    assert str(response1.text).endswith(f'with key {new_filename}"}}')
+    assert response2.status_code == 409
+    assert str(response2.text).startswith(f'{{"detail":"File {new_filename} already exists and cannot be overwritten')
+
+
+@pytest.mark.e2e
+def test_post_file_with_virus_is_blocked():
+    upload_bucket = '{"bucketName": "sds-local"}'
+    upload_virus_file = virus_file.get_data()
+    response = client.post(f"{HOST_URL}/save_file",
+                           headers=token_getter.get_headers(),
+                           files=upload_virus_file,
+                           data={"body": upload_bucket})
+    assert response.status_code == 400
+    assert response.json()["detail"] == ["Virus Found"]
+
+
+@pytest.mark.e2e
+def test_post_file_with_disallowed_file_type_is_blocked():
+    upload_bucket = '{"bucketName": "sds-local"}'
+    upload_disallowed_file = disallowed_file.get_data()
+    response = client.post(f"{HOST_URL}/save_file",
+                           headers=token_getter.get_headers(),
+                           files=upload_disallowed_file,
+                           data={"body": upload_bucket})
+    assert response.status_code == 415
+    assert response.json()["detail"] == "File mimetype not allowed"
+
+
+@pytest.mark.e2e
+def test_post_file_with_missing_bucket_is_blocked():
+    new_filename = make_unique_name("post_new_file_test.txt")
+    upload_file = test_md_file.get_data(new_filename)
+    # Care with formatting the below - value needs to be str, delimted with '
+    # (Although this is just creating a body that lacks bucketName)
+    data = {"body": '{"folder": "testmult"}'}
+    response = client.post(f"{HOST_URL}/save_file",
+                           headers=token_getter.get_headers(),
+                           files=upload_file,
+                           data=data)
+    assert response.status_code == 400
+    assert response.json()["detail"]["bucketName"] == "Field required"
+
+
+@pytest.mark.e2e
+def test_post_file_without_file_fails_as_expected():
+    upload_bucket = '{"bucketName": "sds-local"}'
+
+    response = client.post(f"{HOST_URL}/save_file",
+                           headers=token_getter.get_headers(),
+                           data={"body": upload_bucket})
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == ["File is required"]
+
+
+# Delete File Tests
 
 @pytest.mark.e2e
 def test_delete_single_file():

--- a/tests/end_to_end/test_e2e.py
+++ b/tests/end_to_end/test_e2e.py
@@ -39,8 +39,10 @@ token_getter = TokenManager(client_id=os.getenv('CLIENT_ID'),
 @pytest.fixture(scope="module", autouse=True)
 def setup_and_teardown_test_files():
     """
-    Makes the test files available to each test and closes
-    them afterwards
+    Pre-test setup and post-test teardown for tests within this module (file) only.
+    Makes standard upload files available to each test and closes them afterwards.
+    Code before the "yield" is executed before the tests.
+    Code after the "yield" is exected after the last test.
     """
     global test_md_file, virus_file, disallowed_file
     test_md_file = UploadFileData("Postman/test_file.md")
@@ -54,6 +56,7 @@ def setup_and_teardown_test_files():
 
 @pytest.mark.e2e
 def test_token_can_be_retrieved():
+    "Establish that token retrieval is working"
     token_url = os.getenv('TOKEN_URL', postman_token_url)
     params = {'client_id': os.getenv('CLIENT_ID'),
               'client_secret': os.getenv('CLIENT_SECRET'),
@@ -63,6 +66,21 @@ def test_token_can_be_retrieved():
     response = client.post(token_url, data=params)
     assert response.status_code == 200
     assert "Error" not in response.text
+
+
+@pytest.mark.e2e
+def test_no_token_when_invalid_scope_provided():
+    "Alternative to Postman 'invalid scope token' test"
+    invalid_scope = 'api://laa-sds-local/default'
+    token_url = os.getenv('TOKEN_URL', postman_token_url)
+    params = {'client_id': os.getenv('CLIENT_ID'),
+              'client_secret': os.getenv('CLIENT_SECRET'),
+              'scope': invalid_scope,
+              'grant_type': 'client_credentials'
+              }
+    response = client.post(token_url, data=params)
+    assert response.status_code == 400
+    assert f"The provided value for scope {invalid_scope} is not valid" in response.text
 
 # Health and Status Tests
 

--- a/tests/end_to_end/test_e2e.py
+++ b/tests/end_to_end/test_e2e.py
@@ -35,9 +35,21 @@ token_getter = TokenManager(client_id=os.getenv('CLIENT_ID'),
                             token_url=os.getenv('TOKEN_URL', postman_token_url)
                             )
 
-test_md_file = UploadFileData("Postman/test_file.md")
-virus_file = UploadFileData("Postman/eicar.txt")
-disallowed_file = UploadFileData("Postman/test_file.exe")
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_and_teardown_test_files():
+    """
+    Makes the test files available to each test and closes
+    them afterwards
+    """
+    global test_md_file, virus_file, disallowed_file
+    test_md_file = UploadFileData("Postman/test_file.md")
+    virus_file = UploadFileData("Postman/eicar.txt")
+    disallowed_file = UploadFileData("Postman/test_file.exe")
+    yield
+    test_md_file.close_file()
+    virus_file.close_file()
+    disallowed_file.close_file()
 
 
 @pytest.mark.e2e


### PR DESCRIPTION
## Description of change

Extended pytest e2e tests to cover the same things as the existing Postman tests, but with a few changes.

For convenience these have been added in the same order as the tests are presented in the Postman sidebar, but with exceptions listed below.

Also comments added, e.g. `# Health and Status Tests`,  `# Auth Tests`,  to group related tests together in similar way to our Postman tests. The tests potentially could be split into separate files, although currently seems handy to have them all together for ease of comparison with Postman.

### Exceptions/differences:

- Postman SDSAuthTest "Invalid scope token" not directly covered as this seems more of a test of the authenticator than SDS, as only the authenticator uses the scope token. As alternative, pytest test `test_no_token_when_invalid_scope_provided` directly tests the authenticator. (Note we still have pytest SDS tests for invalid token and missing token)
- Delete file tests "Retrieve Deleted File" and "Retrieve Non-Deleted File" not directly replicated as they seem to just duplicate `retrieve_file` endpoint tests (although they may follow-on from other "delete" tests), and also `retrieve_file` is deprecated. Instead pytest tests `test_delete_single_file_deletes_the_requested_file_only` and `test_file_cannot_be_retrieved_after_it_has_been_deleted` include file retrieval steps. One advantage of pytest is it makes it easier to include multiple requests within the same test like this.

### Additional setup/teardown change
In a previous PR Mae suggested it would be good to make sure that files opened during the tests are closed at the end.   This has now been implemented in the form of new fixture `setup_and_teardown_test_files`.

This  makes three tests files for upload available for each test and closes them at the end of the run. Previously the three files were just opened at the start of the run and never explicitly closed.


## Link to Jira Ticket

- [SDS-164](https://dsdmoj.atlassian.net/browse/SDS-164)

## Screenshots or test evidence if applicable
### Checking the new teardown process actually runs as we want it to
In a local copy I temporarily  added `print("shutdown")` as the last line in the shutdown fixture `setup_and_teardown_test_files`

I ran the tests with a `-s`, so printed output was displayed.

Test results for the last test in the file (`test_virus_check_passes_clean_file `) had the following output which ends with the "shutdown" message:

```
tests/end_to_end/test_e2e.py::test_virus_check_passes_clean_file {"event": "Processed 1 policy files", "logger": "src.utils.multifileadapter", "level": "info", "timestamp": "2025-08-22 12:52.11"}
HTTP Request: POST https://login.microsoftonline.com/c6874728-71e6-41fe-a9e1-2e8c36776ad8/oauth2/v2.0/token "HTTP/1.1 200 OK"
HTTP Request: PUT http://127.0.0.1:8000/virus_check_file "HTTP/1.1 200 OK"
PASSEDshutdown
```
The other tests did not include "shutdown" in their output. This demonstrates that the file closing part of `setup_and_teardown_test_files` is only being executed at the end of the test run as expected. 

Note the "setup" part must be working as expected as: (a) the tests are still passing, so the files are being found (b) I've checked the files are actually uploaded to Localstack S3 via AWS CLI and also seen they have expected size (not zero byte).

### General Test Run
(Ordinary run without "shutdown" message above)
<img width="1796" height="838" alt="image" src="https://github.com/user-attachments/assets/a3c62235-5a9c-4184-a87d-97db93ce0299" />


<!-- Any evidence of change working -->

[SDS-164]: https://dsdmoj.atlassian.net/browse/SDS-164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ