### PR TITLE
SDS-147 - Enable versioning in LocalStack S3

### DIFF
--- a/localstack-script.sh/init-local-sds.sh
+++ b/localstack-script.sh/init-local-sds.sh
@@ -5,6 +5,7 @@ FILE_TO_UPLOAD="README.md"
 # Prepare bucket and folder structure with an initial upload
 echo "SAMPLE CONTENT $(date +%F)" > $FILE_TO_UPLOAD
 awslocal s3api create-bucket --bucket sds-local --create-bucket-configuration LocationConstraint=eu-west-1
+awslocal s3api put-bucket-versioning --bucket sds-local --versioning-configuration Status=Enabled
 awslocal s3 cp $FILE_TO_UPLOAD s3://sds-local/$FILE_TO_UPLOAD
 awslocal s3 cp $FILE_TO_UPLOAD s3://sds-local/CRM14/$FILE_TO_UPLOAD
 


### PR DESCRIPTION
## Description of change
Versioning has been enabled in our AWS-hosted S3 buckets but not in the LocalStack S3 buckets we use for development work. This change enables S3 version in LocalStack too.

- Just a config change with no changes to application code.
- Updated `localstack-script.sh/localstack-script.sh` script to enable versioning in our `sds-local` S3 bucket in LocalStack.

## Link to Jira Ticket

- [SDS-147](https://dsdmoj.atlassian.net/browse/SDS-SDS-147)

## Screenshots or test evidence if applicable
No code changes here, so no updates to our automated tests but here is a demonstration that versioning is now active in a local S3 bucket.

### Getting file version info
Can use AWS CLI to get the version information from README.md in LocalStack S3

```
awslocal --endpoint-url=http://localhost:4566 s3api list-object-versions --bucket sds-local --prefix README.md
```

### Initial State
This shows the below for file in its initial (not-updated) state, with one version as expected:
```
None    None    README.md       None
VERSIONS        FULL_OBJECT     "27dfb48da3c9e14966421d8e752bf251"      True    README.md       2025-09-01T12:58:16+00:00       26      STANDARD        AZkFW1dmf.U.B4dG87Abvev.hXITdM9h
CHECKSUMALGORITHM       CRC32
OWNER   webfile 75aa57f09aa0c8caeab4f8c24e99d10f8e7faeebf76c078efc7c6caea54ba06a
```

### After Update
Updated the file using SDS `save_or_update_file` endpoint, then ran the above command again. Now get two versions listed.

```
None    None    README.md       None
VERSIONS        FULL_OBJECT     "c54385dbe123704dd7660f655f3fda1e"      True    README.md       2025-09-01T13:09:46+00:00       14      STANDARD        AZkFW1dodlMztKA8qSXIFBe726YeywLz
CHECKSUMALGORITHM       SHA256
OWNER   webfile 75aa57f09aa0c8caeab4f8c24e99d10f8e7faeebf76c078efc7c6caea54ba06a
VERSIONS        FULL_OBJECT     "27dfb48da3c9e14966421d8e752bf251"      False   README.md       2025-09-01T12:58:16+00:00       26      STANDARD        AZkFW1dmf.U.B4dG87Abvev.hXITdM9h
CHECKSUMALGORITHM       CRC32
OWNER   webfile 75aa57f09aa0c8caeab4f8c24e99d10f8e7faeebf76c078efc7c6caea54ba06a
```
### After Version Delete

Used the following to delete one of the two versions (AZkFW1dmf.U.B4dG87Abvev.hXITdM9h)

```
awslocal --endpoint-url=http://localhost:4566 s3api delete-object --bucket sds-local --key README.md --version-id  AZkFW1dmf.U.B4dG87Abvev.hXITdM9h
```
After the above, listing the versions shows just the remaining version as expected (with version ID AZkFW1dodlMztKA8qSXIFBe726YeywLz)

```
None    None    README.md       None
VERSIONS        FULL_OBJECT     "c54385dbe123704dd7660f655f3fda1e"      True    README.md       2025-09-01T13:09:46+00:00       14      STANDARD        AZkFW1dodlMztKA8qSXIFBe726YeywLz
CHECKSUMALGORITHM       SHA256
OWNER   webfile 75aa57f09aa0c8caeab4f8c24e99d10f8e7faeebf76c078efc7c6caea54ba06a
```

<!-- Any evidence of change working -->

[SDS-147]: https://dsdmoj.atlassian.net/browse/SDS-147?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ