### PR TITLE
SDS-151:  Update end-to-end tests to include folder checks

### DIFF
--- a/tests/end_to_end/e2e_helpers.py
+++ b/tests/end_to_end/e2e_helpers.py
@@ -161,7 +161,7 @@ def read_postman_env_file(postman_environment_json_file: str
     return environment_info
 
 
-def get_token_maanger() -> TokenManager:
+def get_token_manager() -> TokenManager:
     postman_env_details = read_postman_env_file()
     postman_token_url = postman_env_details.get("AzureTokenUrl")
     return TokenManager(client_id=os.getenv('CLIENT_ID'),

--- a/tests/end_to_end/e2e_helpers.py
+++ b/tests/end_to_end/e2e_helpers.py
@@ -2,6 +2,7 @@ import mimetypes
 import time
 import json
 import os
+from dotenv import load_dotenv
 import boto3
 import httpx as client
 
@@ -10,6 +11,8 @@ import httpx as client
 Everything here is intended to support end-to-end tests.
 This is not application code.
 """
+
+load_dotenv()
 
 
 class TokenManager:
@@ -146,3 +149,20 @@ def read_postman_env_file(postman_environment_json_file: str
             break
 
     return environment_info
+
+
+def get_token_maanger() -> TokenManager:
+    postman_env_details = read_postman_env_file()
+    postman_token_url = postman_env_details.get("AzureTokenUrl")
+    return TokenManager(client_id=os.getenv('CLIENT_ID'),
+                        client_secret=os.getenv('CLIENT_SECRET'),
+                        token_url=os.getenv('TOKEN_URL', postman_token_url)
+                        )
+
+
+def get_host_url() -> str:
+    return os.getenv('HOST_URL', 'http://127.0.0.1:8000')
+
+
+def get_upload_body() -> dict[str, dict[str, str]]:
+    return {"body": '{"bucketName": "sds-local"}'}

--- a/tests/end_to_end/test_e2e.py
+++ b/tests/end_to_end/test_e2e.py
@@ -3,7 +3,7 @@ import pytest
 # Using `as client`, so can easily switch between httpx and requests
 import httpx as client
 from tests.end_to_end.e2e_helpers import UploadFileData
-from tests.end_to_end.e2e_helpers import get_token_maanger
+from tests.end_to_end.e2e_helpers import get_token_manager
 from tests.end_to_end.e2e_helpers import get_host_url
 from tests.end_to_end.e2e_helpers import get_upload_body
 from tests.end_to_end.e2e_helpers import make_unique_name
@@ -29,7 +29,7 @@ Environment Variables
 
 HOST_URL = get_host_url()
 UPLOAD_BODY = get_upload_body()
-token_getter = get_token_maanger()
+token_getter = get_token_manager()
 
 
 @pytest.fixture(scope="module", autouse=True)

--- a/tests/end_to_end/test_e2e.py
+++ b/tests/end_to_end/test_e2e.py
@@ -1,10 +1,11 @@
 import os
 import pytest
-from dotenv import load_dotenv
 # Using `as client`, so can easily switch between httpx and requests
 import httpx as client
-from tests.end_to_end.e2e_helpers import TokenManager, UploadFileData
-from tests.end_to_end.e2e_helpers import read_postman_env_file
+from tests.end_to_end.e2e_helpers import UploadFileData
+from tests.end_to_end.e2e_helpers import get_token_maanger
+from tests.end_to_end.e2e_helpers import get_host_url
+from tests.end_to_end.e2e_helpers import get_upload_body
 from tests.end_to_end.e2e_helpers import make_unique_name
 from tests.end_to_end.e2e_helpers import post_a_file
 from tests.end_to_end.e2e_helpers import LocalS3
@@ -25,20 +26,9 @@ Environment Variables
     TOKEN_URL - optional, defaults to value in Postman/SDSLocal.postman_environment.json file
 """
 
-
-postman_env_details = read_postman_env_file()
-postman_token_url = postman_env_details.get("AzureTokenUrl")
-
-load_dotenv()
-HOST_URL = os.getenv('HOST_URL', 'http://127.0.0.1:8000')
-token_getter = TokenManager(client_id=os.getenv('CLIENT_ID'),
-                            client_secret=os.getenv('CLIENT_SECRET'),
-                            token_url=os.getenv('TOKEN_URL', postman_token_url)
-                            )
-
-# Note the value is a str, not dict, and the single/double quotes need to be this particular way
-UPLOAD_BODY = {"body": '{"bucketName": "sds-local"}'}
-
+HOST_URL = get_host_url()
+UPLOAD_BODY = get_upload_body()
+token_getter = get_token_maanger()
 s3_client = LocalS3()
 
 
@@ -63,7 +53,7 @@ def setup_and_teardown_test_files():
 @pytest.mark.e2e
 def test_token_can_be_retrieved():
     "Establish that token retrieval is working"
-    token_url = os.getenv('TOKEN_URL', postman_token_url)
+    token_url = os.getenv('TOKEN_URL', token_getter.token_url)
     params = {'client_id': os.getenv('CLIENT_ID'),
               'client_secret': os.getenv('CLIENT_SECRET'),
               'scope': 'api://laa-sds-local/.default',
@@ -78,7 +68,7 @@ def test_token_can_be_retrieved():
 def test_no_token_when_invalid_scope_provided():
     "Alternative to Postman 'invalid scope token' test"
     invalid_scope = 'api://laa-sds-local/default'
-    token_url = os.getenv('TOKEN_URL', postman_token_url)
+    token_url = os.getenv('TOKEN_URL', token_getter.token_url)
     params = {'client_id': os.getenv('CLIENT_ID'),
               'client_secret': os.getenv('CLIENT_SECRET'),
               'scope': invalid_scope,

--- a/tests/end_to_end/test_e2e.py
+++ b/tests/end_to_end/test_e2e.py
@@ -8,7 +8,6 @@ from tests.end_to_end.e2e_helpers import get_host_url
 from tests.end_to_end.e2e_helpers import get_upload_body
 from tests.end_to_end.e2e_helpers import make_unique_name
 from tests.end_to_end.e2e_helpers import post_a_file
-from tests.end_to_end.e2e_helpers import LocalS3
 
 """
 This file is for e2e tests that require an actual SDS application to run against.
@@ -31,7 +30,6 @@ Environment Variables
 HOST_URL = get_host_url()
 UPLOAD_BODY = get_upload_body()
 token_getter = get_token_maanger()
-s3_client = LocalS3()
 
 
 @pytest.fixture(scope="module", autouse=True)

--- a/tests/end_to_end/test_e2e.py
+++ b/tests/end_to_end/test_e2e.py
@@ -15,6 +15,8 @@ This file is for e2e tests that require an actual SDS application to run against
 They all should be decorated with custom marker, @pytest.mark.e2e, to enable them
 to be run separately from pytest unit tests.
 
+* These tests mainly replicate our Postman tests but with a few differences *
+
 Manual test execution for e2e only or excluding e2e:
     `pipenv run pytest -m e2e` - to run e2e tests only
     `pipenv run pytest -m "not e2e"` - to exclude e2e tests from run.
@@ -363,27 +365,6 @@ def test_post_file_without_file_fails_as_expected():
     response = client.post(f"{HOST_URL}/save_file", headers=token_getter.get_headers(), data=UPLOAD_BODY)
     assert response.status_code == 400
     assert response.json()["detail"] == ["File is required"]
-
-
-new_filename = make_unique_name("save_path_file.txt")
-paths = [f"{p}{new_filename}" for p in ("", "f1/", "f1/f2/")]
-
-
-@pytest.mark.e2e
-@pytest.mark.parametrize("new_filename", paths)
-def test_post_file_paths_works_as_expected(new_filename):
-    upload_file = test_md_file.get_data(new_filename)
-
-    response = client.post(f"{HOST_URL}/save_file",
-                           headers=token_getter.get_headers(),
-                           files=upload_file,
-                           data=UPLOAD_BODY)
-
-    details = response.json()
-    assert response.status_code == 201
-    assert details["success"].startswith("File saved successfully")
-    assert details["success"].endswith(f"with key {new_filename}")
-    assert s3_client.check_file_exists(new_filename) is True
 
 
 # Delete File Tests

--- a/tests/end_to_end/test_e2e_file_and_folder.py
+++ b/tests/end_to_end/test_e2e_file_and_folder.py
@@ -2,7 +2,7 @@ import pytest
 # Using `as client`, so can easily switch between httpx and requests
 import httpx as client
 from tests.end_to_end.e2e_helpers import UploadFileData
-from tests.end_to_end.e2e_helpers import get_token_maanger
+from tests.end_to_end.e2e_helpers import get_token_manager
 from tests.end_to_end.e2e_helpers import get_host_url
 from tests.end_to_end.e2e_helpers import get_upload_body
 from tests.end_to_end.e2e_helpers import make_unique_name
@@ -30,11 +30,14 @@ Environment Variables
 
 HOST_URL = get_host_url()
 UPLOAD_BODY = get_upload_body()
-token_getter = get_token_maanger()
+token_getter = get_token_manager()
 # Set to return genuine S3 responses when HOST is local ("http://127.0.0.1:8000")
 # otherwise s3_client.check_file_exists returns a mock value. This is to save on
 # having to set S3 credentials for every environment.
-s3_client = LocalS3(mocking_enabled=(HOST_URL != "http://127.0.0.1:8000"))
+if HOST_URL == "http://127.0.0.1:8000":
+    s3_client = LocalS3(mocking_enabled=False)
+else:
+    s3_client = LocalS3(mocking_enabled=True)
 
 
 @pytest.fixture(scope="module", autouse=True)

--- a/tests/end_to_end/test_e2e_file_and_folder.py
+++ b/tests/end_to_end/test_e2e_file_and_folder.py
@@ -84,20 +84,24 @@ def test_get_file_paths_works_as_expected(new_filename):
     _ = post_a_file(url=HOST_URL, headers=headers, file_data=test_md_file.get_data(new_filename))
     # Get the file using SDS API (this gives URL to file, not the actual content)
     get_response = client.get(f"{HOST_URL}/get_file", headers=headers, params={"file_key": new_filename})
+    """
     # Read the actual file content using URL extracted from SDS response
     json_data = get_response.json()
     file_url = json_data.get("fileURL")
     download_response = client.get(file_url)
+    """
     # Asserts
     assert get_response.status_code == 200
     assert "fileURL" in get_response.text
     assert "Expires" in get_response.text
     assert new_filename in get_response.text
+    """
     assert download_response.status_code == 200
     # Currently a fixed result because we're only using one physical file but assigning a different
     # filename on upload. Future improvement would be to use files with distinct contents so we
     # can distinguish if we're getting the right content for each.
     assert download_response.text.startswith("# laa-secure-document-storage-api\n")
+    """
 
 
 @pytest.mark.e2e

--- a/tests/end_to_end/test_e2e_file_and_folder.py
+++ b/tests/end_to_end/test_e2e_file_and_folder.py
@@ -84,6 +84,8 @@ def test_get_file_paths_works_as_expected(new_filename):
     _ = post_a_file(url=HOST_URL, headers=headers, file_data=test_md_file.get_data(new_filename))
     # Get the file using SDS API (this gives URL to file, not the actual content)
     get_response = client.get(f"{HOST_URL}/get_file", headers=headers, params={"file_key": new_filename})
+    # Two blocks of commented-out code in this test concern downloading the actual file.
+    # These work locally but fail in code pipeline.
     """
     # Read the actual file content using URL extracted from SDS response
     json_data = get_response.json()

--- a/tests/end_to_end/test_e2e_file_and_folder.py
+++ b/tests/end_to_end/test_e2e_file_and_folder.py
@@ -1,0 +1,72 @@
+import pytest
+# Using `as client`, so can easily switch between httpx and requests
+import httpx as client
+from tests.end_to_end.e2e_helpers import UploadFileData
+from tests.end_to_end.e2e_helpers import get_token_maanger
+from tests.end_to_end.e2e_helpers import get_host_url
+from tests.end_to_end.e2e_helpers import get_upload_body
+from tests.end_to_end.e2e_helpers import make_unique_name
+from tests.end_to_end.e2e_helpers import LocalS3
+
+"""
+This file is for e2e tests that require an actual SDS application to run against.
+They all should be decorated with custom marker, @pytest.mark.e2e, to enable them
+to be run separately from pytest unit tests.
+
+* These tests mainly concern different types of file or folder. *
+
+Manual test execution for e2e only or excluding e2e:
+    `pipenv run pytest -m e2e` - to run e2e tests only
+    `pipenv run pytest -m "not e2e"` - to exclude e2e tests from run.
+
+Environment Variables
+    CLIENT_ID - required
+    CLIENT_SECRET - required
+    HOST_URL - optional, defaults to http://127.0.0.1:8000
+    TOKEN_URL - optional, defaults to value in Postman/SDSLocal.postman_environment.json file
+"""
+
+
+HOST_URL = get_host_url()
+UPLOAD_BODY = get_upload_body()
+token_getter = get_token_maanger()
+s3_client = LocalS3()
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_and_teardown_test_files():
+    """
+    Pre-test setup and post-test teardown for tests within this module (file) only.
+    Makes standard upload files available to each test and closes them afterwards.
+    Code before the "yield" is executed before the tests.
+    Code after the "yield" is exected after the last test.
+    """
+    global test_md_file, virus_file, disallowed_file
+    test_md_file = UploadFileData("Postman/test_file.md")
+    virus_file = UploadFileData("Postman/eicar.txt")
+    disallowed_file = UploadFileData("Postman/test_file.exe")
+    yield
+    test_md_file.close_file()
+    virus_file.close_file()
+    disallowed_file.close_file()
+
+
+new_filename = make_unique_name("save_path_file.txt")
+paths = [f"{p}{new_filename}" for p in ("", "f1/", "f1/f2/")]
+
+
+@pytest.mark.e2e
+@pytest.mark.parametrize("new_filename", paths)
+def test_post_file_paths_works_as_expected(new_filename):
+    upload_file = test_md_file.get_data(new_filename)
+
+    response = client.post(f"{HOST_URL}/save_file",
+                           headers=token_getter.get_headers(),
+                           files=upload_file,
+                           data=UPLOAD_BODY)
+
+    details = response.json()
+    assert response.status_code == 201
+    assert details["success"].startswith("File saved successfully")
+    assert details["success"].endswith(f"with key {new_filename}")
+    assert s3_client.check_file_exists(new_filename) is True

--- a/tests/end_to_end/test_e2e_file_and_folder.py
+++ b/tests/end_to_end/test_e2e_file_and_folder.py
@@ -82,12 +82,22 @@ def test_get_file_paths_works_as_expected(new_filename):
     headers = token_getter.get_headers()
     # Upload file to S3 so it's available to be retrieved
     _ = post_a_file(url=HOST_URL, headers=headers, file_data=test_md_file.get_data(new_filename))
-    # Get the file using SDS API
-    response = client.get(f"{HOST_URL}/get_file", headers=headers, params={"file_key": new_filename})
-    assert response.status_code == 200
-    assert "fileURL" in response.text
-    assert "Expires" in response.text
-    assert new_filename in response.text
+    # Get the file using SDS API (this gives URL to file, not the actual content)
+    get_response = client.get(f"{HOST_URL}/get_file", headers=headers, params={"file_key": new_filename})
+    # Read the actual file content using URL extracted from SDS response
+    json_data = get_response.json()
+    file_url = json_data.get("fileURL")
+    download_response = client.get(file_url)
+    # Asserts
+    assert get_response.status_code == 200
+    assert "fileURL" in get_response.text
+    assert "Expires" in get_response.text
+    assert new_filename in get_response.text
+    assert download_response.status_code == 200
+    # Currently a fixed result because we're only using one physical file but assigning a different
+    # filename on upload. Future improvement would be to use files with distinct contents so we
+    # can distinguish if we're getting the right content for each.
+    assert download_response.text.startswith("# laa-secure-document-storage-api\n")
 
 
 @pytest.mark.e2e

--- a/tests/end_to_end/test_e2e_file_and_folder.py
+++ b/tests/end_to_end/test_e2e_file_and_folder.py
@@ -31,7 +31,7 @@ HOST_URL = get_host_url()
 UPLOAD_BODY = get_upload_body()
 token_getter = get_token_maanger()
 # Set to return genuine S3 responses when HOST is local ("http://127.0.0.1:8000")
-# otherwise s3_client.check_file_exists returns a moack value. This is to save on
+# otherwise s3_client.check_file_exists returns a mock value. This is to save on
 # having to set S3 credentials for every environment.
 s3_client = LocalS3(mocking_enabled=(HOST_URL != "http://127.0.0.1:8000"))
 
@@ -51,7 +51,7 @@ def setup_and_teardown_test_files():
 
 
 new_base_filename = make_unique_name("save_path_file.txt")
-paths = [f"{p}{new_base_filename}" for p in ("", "f1/", "f1/f2/", "f1/f2/f3")]
+paths = [f"{p}{new_base_filename}" for p in ("", "f1/", "f1/f2/", "f1/f2/f3/")]
 
 
 @pytest.mark.e2e


### PR DESCRIPTION
## Description of change

### New e2e pytest tests
New tests for the following:

1. Save files with folders specified, one or more levels deep.
2. Get file with folders specified, one or more levels deep.
3. Save/update files with unusual but valid filenames.
4. Save/update files with unusual but invalid filenames.

Note: 
- The details of what counts as valid/invalid could change due to separate work under ticket SDS-165 "Expand SDS file validation". The new tests all accept parametrised data which should enable them to be conveniently updated in response to changes in the rules.
- The new tests are in new file `test_e2e_file_and_folder.py`. Idea is to keep the original `test_e2e.py` file to cover the same things as our Postman tests.
- Item 1 above deliberately uses Save (so no updates) as a way of establishing that e.g. `test.md` and `myfolder/test.md` are not treated as the same file and don't cause a "file already exists" errors when saved one after the other. Note there is a time-based element to these filenames that's set each run to enable re-running.
- Items 3 and 4 deliberately use Save/Update (so updates allowed) because they include fixed particular filenames, so allowing update is necessary for the tests to be re-runnable without having to take the trouble to delete pre-existing files.
- Item 4 asserts don't include checking the error message because the current error message is misleading and probably should be changed (message is `File extension not allowed` ) 

### Additional changes:
- Test environment config made more systematic, with more setup moved into `e2e_helpers.py` to be more reusable
- Added ability to check the contents of S3 directly using boto3, so we can confirm actual bucket content. This is also set to only be active when tests run locally, to save on having to set S3 credentials for each environment. Mock S3 results are automatically supplied in other environments.
- I had changed the new get file test to also get the file content using the retrieved download URL and check the first line of text. However, I found this fails in the pipeline with error `httpcore.ConnectError: [Errno -3] Temporary failure in name resolution`.  I've commented out the code that does this step for now, but this should still work if uncommented when running locally.

### Pedantic sidenote
I don't think S3 truly has folders in a proper hierarchical filing system, just things called `prefixes` that _resemble_ folders. I suppose the main thing is if a client provides a filename that includes a folder path, then it should be saved to S3 with a `prefix` based on the same path. 

## Link to Jira Ticket

- [SDS-151](https://dsdmoj.atlassian.net/browse/SDS-151)

## Screenshots or test evidence if applicable

<!-- Any evidence of change working -->
As a quick check that the S3 mocking isn't active when environment is local, I deliberately sabotaged `test_post_file_paths_works_as_expected` so that the supplied filename in the S3 part of the test was wrong. This means the test would pass if mocking active but fail if mocking inactive. In actual local run the test failed, indicating that mocking was not active as expected.

Usual pytest e2e run

<img width="1876" height="1264" alt="image" src="https://github.com/user-attachments/assets/b667f5f2-b35d-48d8-b4ed-7312d1170b02" />




[SDS-151]: https://dsdmoj.atlassian.net/browse/SDS-151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ