### PR TITLE
change json_validator to use pydantic model_validate_json method

### DIFF
--- a/src/validation/json_validator.py
+++ b/src/validation/json_validator.py
@@ -8,9 +8,11 @@ def validate_json(model: Type[BaseModel]):
         try:
             return model.model_validate_json(body)
         except ValidationError as exc:
-            # error['loc'] is a tuple which can be empty. Can't use this tuple as key in our data extract because it breaks
-            # later json encoding. Using comma-separated string representation of the tuple's contents a key in error_details.
-            error_details = {",".join(str(c) for c in error['loc']): error['msg'] for error in exc.errors()}
+            # error['loc'] is a tuple which can be empty. Can't use this tuple as key in our data extract because
+            # it breaks later json encoding. Using comma-separated string representation of the tuple's contents as
+            # key in error_details.
+            error_details = {",".join(str(e) for e in error['loc']): error['msg']
+                             for error in exc.errors()}
             raise HTTPException(status_code=400, detail=error_details)
 
     return wrapper


### PR DESCRIPTION
## Description of change
We were getting warnings from pytest saying that Pydantic's `parse_raw` method has been deprecated and advising it should be replaced with the new `model_validate_json` method instead. 

Our `validate_json` validator function is the only place where we're using `parse_raw`. This change replaces this with with`model_validate_json`. 

(For completeness, we're also getting warnings about Pydantic's `load_str_bytes` being deprecated but we don't actually use it in our own code. It's being picked up because it's used by the standard Pydanic library itself. Presumably this one is a self-fixing problem if we update Pydantic)

### Complication
After switching to `model_validate_json` two of our "invalid data" unit tests started failing with "index out of range" errors:

- `test_save_file.py::test_save_or_update_file_with_invalid_data`
- `test_upload_file.py::test_save_file_invalid_data`

This is because when there's a ValidationError, `model_validate_json` returns exception details in a slightly different format from `parse_raw`. We have code that tries to extract a subset of the exception details and this expects a dictionary value with key `loc` and a value that's a non-empty tuple, from which we extract the first element. However, when we use `model_validate_json` this particular tuple can be empty, resulting in an "index out of range" error.

For example, the error details returned by `model_validate_json` can look like this:
```
{'type': 'json_invalid', 'loc': (), 'msg': 'Invalid JSON: trailing characters at line 1 column 3', 'input': '{}}', 'ctx': {'error': 'trailing characters at line 1 column 3'}, 'url': 'https://errors.pydantic.dev/2.11/v/json_invalid'}
```
Although our unit tests create a situation with a non-empty 'loc' value:
```
{'type': 'missing', 'loc': ('bucketName',), 'msg': 'Field required', 'input': {}, 'url': 'https://errors.pydantic.dev/2.11/v/missing'}
```
We therefore need to change the way `validate_json` validator extracts error details so it no longer relies on `loc` having a non empty tuple.

Another complication is we're using the value from `['loc'][0]` as a key in our own `error_details` which raises the question of _what should we used when this has an empty tuple_? Note we can't use the tuple itself as a key because any tuple key results in a downstream json encoding error (whether or not the tuple is empty).

A fix that works, is to convert the contents of the tuple into a comma-separated string. This should mean we get a distinct key regardless of the number of elements in the tuple, plus this doesn't cause subsequent json errors. Also significantly, this returns details that are compatible with our existing unit tests .

### Consistency Question
Also question of whether we want all validators to return error details that share a consistent format? From a quick look they currently don't do this but it might be worth changing things in future to make them consistent.

However, the  `validate_json` "validator" that's used here isn't applied like our other validators, so it may not need to be consistent anyway. It's only used by the save file and save/update file routers to validate the request body using FastAPI `Dependency` - not a file validator.

_Also wonder if this validation is actually needed, although beyond scope of this simple change to remove it?_

### Comprehensibility of comprehension!
We now have a nested comprehension which keeps things nice and concise but perhaps in a form that's not so easy to understand. Might be clearer to bust this out into an actual for-loop?


## Link to Jira Ticket

- [SDS-166](https://dsdmoj.atlassian.net/browse/SDS-166)

## Screenshots or test evidence if applicable

Unit
<img width="1971" height="467" alt="image" src="https://github.com/user-attachments/assets/126ac6a1-0110-4536-91b4-5eba47bf9c20" />

E2E
<img width="1981" height="128" alt="image" src="https://github.com/user-attachments/assets/d62b2af6-6886-41c6-aa18-4f87ab1538d3" />


[SDS-166]: https://dsdmoj.atlassian.net/browse/SDS-166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ