### PR TITLE
remove default params from file validators

### DIFF
--- a/configbuilder.py
+++ b/configbuilder.py
@@ -62,7 +62,9 @@ def get_kwargs_for_filevalidator(validator: str | FileValidator) -> Dict[str, An
             value = validator_defaults[i]
             if value is list:
                 value = []
-        except ValueError:
+        # TypeError added as quick fix because validator args no longer have defaults, except sometimes list,
+        # so `value = validator_defaults[i]` can get TypeError: 'NoneType' object is not subscriptable.
+        except (ValueError, TypeError):
             value = None
         validator_kwargs[arg] = value
     return validator_kwargs

--- a/src/validation/file_validator.py
+++ b/src/validation/file_validator.py
@@ -37,7 +37,7 @@ class FileValidator(abc.ABC):
 class MaxFileSize(FileValidator):
     continue_to_next_validator_on_fail = True
 
-    def validate(self, file_object, size: int = 1, **kwargs) -> Tuple[int, str]:
+    def validate(self, file_object, size: int, **kwargs) -> Tuple[int, str]:
         """
         Validates that the file is at most a certain size.
 
@@ -60,7 +60,7 @@ class MaxFileSize(FileValidator):
 class MinFileSize(FileValidator):
     continue_to_next_validator_on_fail = True
 
-    def validate(self, file_object, size: int = 1, **kwargs) -> Tuple[int, str]:
+    def validate(self, file_object, size: int, **kwargs) -> Tuple[int, str]:
         """
         Validates that the file is at least a certain size.
 

--- a/tests/validation_tests/test_client_configured_validator.py
+++ b/tests/validation_tests/test_client_configured_validator.py
@@ -44,8 +44,8 @@ def test_generate_all_filevalidatorspecs_returns_kwargs():
                                                             ("AllowedMimetypes", {'content_types': []}),
                                                             ("DisallowedFileExtensions", {'extensions': []}),
                                                             ("DisallowedMimetypes", {'content_types': []}),
-                                                            ("MaxFileSize", {'size': 1}),
-                                                            ("MinFileSize", {'size': 1})
+                                                            ("MaxFileSize", {'size': None}),
+                                                            ("MinFileSize", {'size': None})
                                                             ])
 def test_get_kwargs_for_filevalidator_works_with_string_param(validator_name, expected_result):
     kwargs = get_kwargs_for_filevalidator(validator_name)
@@ -56,8 +56,8 @@ def test_get_kwargs_for_filevalidator_works_with_string_param(validator_name, ex
                                                        (AllowedMimetypes, {'content_types': []}),
                                                        (DisallowedFileExtensions, {'extensions': []}),
                                                        (DisallowedMimetypes, {'content_types': []}),
-                                                       (MaxFileSize, {'size': 1}),
-                                                       (MinFileSize, {'size': 1})
+                                                       (MaxFileSize, {'size': None}),
+                                                       (MinFileSize, {'size': None})
                                                        ])
 def test_get_kwargs_for_filevalidator_works_with_validator_param(validator, expected_result):
     kwargs = get_kwargs_for_filevalidator(validator)


### PR DESCRIPTION
## Description of change
This removes all default specific values from the parameters in our file validators' `validate` methods.
This is because these are all client-configured validators, so take parameter values from client-config files. This means the defaults should never get used, so their presence is misleading. (Plus this also makes the file validators consistent with recently added file collection validators which don't have these defaults.)

**Unchanged**
Validator parameters that are defaulted to `list`, as this is just a way of enabling multiple values to be assigned to a parameter but does not actually set any default values.

### What's updated
- Only two file-validatorsvalidators had defaults: `MaxFileSize`and `MaxFileSize`, which both had a `size` parameter with default of 1. This default now removed.
- Updated expected results of unit tests `test_get_kwargs_for_filevalidator_works_with_string_param` and `test_get_kwargs_for_filevalidator_works_with_validator_param` to have expected `size` values of `None` instead of `1`.
- A small fix to `configbuilder.py` because it was expecting default values and failing without them. Quick fix so that it still works.

<!-- Description of the changes made -->

## Link to Jira Ticket

- [SDS-239](https://dsdmoj.atlassian.net/browse/SDS-239)

## Screenshots or test evidence if applicable
### Routine
Usual unit tests and e2e tests pass.

### available_validators endpoint
Information reported by `available_validators` endpoint fits the new situation:
<img width="1510" height="261" alt="image" src="https://github.com/user-attachments/assets/ee639056-0836-4919-a616-62c6d251e857" />

### Config Builder
Initially our config builder `configbuilder.py` failed with `TypeError: 'NoneType' object is not subscriptable` because it was expecting validator default vaules

I made a small fix to the config builder so it could run. After this it worked and I was able to use it to create a config that included setting  `MaxFileSize`and `MinFileSize`, and these values were correctly saved to the json file.

<img width="811" height="237" alt="image" src="https://github.com/user-attachments/assets/5aa07127-33d4-4c70-892c-62e355bb5bda" />

<img width="382" height="448" alt="image" src="https://github.com/user-attachments/assets/eca998f5-fd53-4bd3-baa6-c9eb961df14b" />



[SDS-239]: https://dsdmoj.atlassian.net/browse/SDS-239?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ