### PR TITLE
also use folders to indicate test type

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -40,4 +40,4 @@ jobs:
 
     - name: Unit test with pytest
       run: |
-        pipenv run pytest -v -m "not e2e"
+        pipenv run pytest --ignore tests/end_to_end -v -m "not e2e"

--- a/.github/workflows/pytest-e2e-tests.yml
+++ b/.github/workflows/pytest-e2e-tests.yml
@@ -91,7 +91,7 @@ jobs:
 
       - name: Run Pytest e2e Tests
         run: |
-          pipenv run pytest -v -m e2e
+          pipenv run pytest tests/end_to_end -v -m e2e
         env:
           CLIENT_ID: ${{ secrets.CLIENT_ID }}
           CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}

--- a/README.md
+++ b/README.md
@@ -126,13 +126,13 @@ $ pipenv install --dev
 And then run:
 
 ```shell
-$ pipenv run pytest -m "not e2e"
+$ pipenv run pytest --ignore tests/end_to_end -m "not e2e"
 ```
 ### API testing with pytest
 In additionl to pytest unit testing, we also have end-to-end tests that run via pytest. These run in the pipeline and can be run locally. These use the same requirements as above, and are run locally using:
 
 ```
-$ pipenv run pytest -m e2e
+$ pipenv run pytest tests/end_to_end -m e2e
 ```
 
 To run all the pytest tests, regardless of type, run:
@@ -140,6 +140,19 @@ To run all the pytest tests, regardless of type, run:
 ```
 $ pipenv run pytest
 ```
+
+### pytest test-type separation
+As mentioned above, we have both unit tests and end-to-end tests that are run using `pytest`. These two types of test need to be distinguished so they can be run separately. This is acheived as follows:
+
+#### end-to-end
+- Must be within folder `tests/end_to_end`
+- Each test function marked with decorator `@pytest.mark.e2e`
+
+#### unit tests
+- Within `tests` folder but NOT in `tests/end_to_end`
+- NOT marked with decorator `@pytest.mark.e2e`
+
+This provides two ways of separating the tests: one by file location and another by `e2e` tag.
 
 ### API testing with Postman
 


### PR DESCRIPTION
## Description of change 

### Original Situation
We have both unit tests and end-to-end tests that are run using pytest. Separation between these two types of tests was achieved by marking e2e test functions with decorator `@pytest.mark.e2e`. Tests were invoked as follows: `pipenv run pytest -m "not e2e"` and `pipenv run pytest -m e2e`. This works but has a drawback in that the `@pytest.mark.e2e` decorator can only be applied to test functions, so any test setup/teardown code that sits outside a test function cannot be managed in this way and will run for both sets of tests, even when not relevant to both.

### Improved Version
We can also specify tests by providing the folder they're located in or exclude tests in a particular folder by using  pytest's `--ignore`  parameter. Our tests are already in particular folders, so we can also run each set using:

`pipenv run pytest tests/end_to_end`
`pipenv run pytest --ignore tests/end_to_end`

It's also possible to combine both methods (tags and folder):
`pipenv run pytest tests/end_to_end -m e2e `
`pipenv run pytest --ignore tests/end_to_end  -m "not e2e"`
 
By also specifying the folders, irrelevant setup/teardown code will be skipped. There also appears to be a slight performance increase, which makes sense as some files are now being excluded. Another advantage is "deselected" test counts no longer appear in results summary. 

### What's changed
- Readme file updated with the new way of invoking the tests that use both folder and tags.
- Also a bit of explanation added to the readme
- "linting" github action now invokes unit tests using `pipenv run pytest --ignore tests/end_to_end -v -m "not e2e"`
- Pytest e2e github action now invokes e2e tests using `pipenv run pytest tests/end_to_end -v -m e2e`

## Link to Jira Ticket

- [SDS-193](https://dsdmoj.atlassian.net/browse/SDS-193)

## Screenshots or test evidence if applicable

###  Local run e2e - old way
`pipenv run pytest -m e2e`
Result ends with 
`125 passed, 445 deselected in 35.03s`

### Local run e2e - new way
`pipenv run pytest tests/end_to_end -m e2e`
Result ends with
` 125 passed in 31.34s `
Same tests run .
We no longer have the confusing "deselected" part of the message.
Also slightly quicker but might be a coincidence

###  Local run unit tests - old way
`pipenv run pytest -m "not e2e"`
Result ends with:
`445 passed, 125 deselected in 1.12s`

### Local run unit tests - new way
`pipenv run pytest --ignore tests/end_to_end  -m "not e2e"`
Result ends with:
`445 passed in 0.98s`
Same tests run.
Again, no longer have confusing "deselected" part of the message.
Again  a bit quicker but might be coincidence.

### Pipeline tests
These are showing as "passed". Also checked log messages to see test counts are OK.
Get `445 passed in 2.25s` from "Linting and Unit Test" - correct
Get `125 passed in 47.08s` from "Pytest End-to-end Tests" - correct

[SDS-193]: https://dsdmoj.atlassian.net/browse/SDS-193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ`