### PR TITLE
SDS-242 - Add get_file_details endpoint

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -29,6 +29,7 @@ from src.routers.virus_check_file import router as virus_check_file
 from src.routers.available_validators import router as available_validators
 from src.routers.bulk_upload import router as bulk_upload
 from src.routers.scan_for_suspicious_content import router as scan_for_suspicious_content
+from src.routers.file_details import router as get_file_details
 
 
 def add_correlation(
@@ -98,3 +99,4 @@ app.include_router(health)
 app.include_router(root)
 
 app.include_router(available_validators)
+app.include_router(get_file_details)

--- a/src/routers/file_details.py
+++ b/src/routers/file_details.py
@@ -1,0 +1,47 @@
+import structlog
+from fastapi import APIRouter, HTTPException, Depends, Request
+from fastapi.params import Query
+
+from src.middleware.client_config_middleware import client_config_middleware
+from src.models.client_config import ClientConfig
+
+from src.services.s3_service import list_file_versions
+
+
+router = APIRouter()
+logger = structlog.get_logger()
+
+
+@router.get('/get_file_details')
+async def get_file_details(
+    request: Request,
+    file_key: str = Query(None, min_length=1),
+    client_config: ClientConfig = Depends(client_config_middleware),
+):
+    """
+    Get version history for the specified `file_key`.
+
+    Returns the following for each version: `Key`, `VersionId`, `IsLatest`, `Size`, `LastModified`, e.g.
+    ```
+    {"version_history":[{"Key":"README.md","VersionId":"AZ2.eOOs_UrTIR36qVsTPRm7lJupRZTI","IsLatest":true,"Size":320,"LastModified":"2026-04-24T13:39:38+00:00"},{"Key":"README.md","VersionId":"AZ2.eOOinemjh3PiPMRoTQzUpoxcqMKo","IsLatest":false,"Size":260,"LastModified":"2026-04-23T07:51:26+00:00"}]}
+    ```
+    """
+    error_status = ()
+    if not file_key:
+        error_status = (400, "File key is missing")
+
+    if not error_status:
+        file_versions = list_file_versions(client_config, file_key)
+        if file_versions == []:
+            error_status = (410, f"No details found for file: {file_key}")
+
+    if error_status:
+        raise HTTPException(status_code=error_status[0], detail=error_status[1])
+
+    # Do we want an audit record for this?
+
+    # Extract subset of details for client
+    details_for_client = [{key: version.get(key) for key in ("Key", "VersionId", "IsLatest", "Size", "LastModified")}
+                          for version in file_versions]
+
+    return {"version_history": details_for_client}

--- a/src/routers/file_details.py
+++ b/src/routers/file_details.py
@@ -6,6 +6,8 @@ from src.middleware.client_config_middleware import client_config_middleware
 from src.models.client_config import ClientConfig
 
 from src.services.s3_service import list_file_versions
+from src.services import audit_service
+from src.utils.operation_types import OperationType
 
 
 router = APIRouter()
@@ -35,10 +37,15 @@ async def get_file_details(
         if file_versions == []:
             error_status = (404, f"No details found for file: {file_key}")
 
+    audit_service.add_record(request=request,
+                             filename_position=0,
+                             service_id=client_config.azure_display_name,
+                             file_id=file_key,
+                             operation_type=OperationType.INFO,
+                             error_status=error_status)
+
     if error_status:
         raise HTTPException(status_code=error_status[0], detail=error_status[1])
-
-    # Do we want an audit record for this?
 
     # Extract subset of details for client
     details_for_client = [{key: version.get(key) for key in ("Key", "VersionId", "IsLatest", "Size", "LastModified")}

--- a/src/routers/file_details.py
+++ b/src/routers/file_details.py
@@ -33,7 +33,7 @@ async def get_file_details(
     if not error_status:
         file_versions = list_file_versions(client_config, file_key)
         if file_versions == []:
-            error_status = (410, f"No details found for file: {file_key}")
+            error_status = (404, f"No details found for file: {file_key}")
 
     if error_status:
         raise HTTPException(status_code=error_status[0], detail=error_status[1])

--- a/src/utils/operation_types.py
+++ b/src/utils/operation_types.py
@@ -6,4 +6,5 @@ class OperationType(Enum):
     UPDATE = 'UPDATE'
     DELETE = 'DELETE'
     READ = 'READ'
+    INFO = 'INFO'
     FAILED = 'FAILED'

--- a/tests/end_to_end/test_e2e_file_and_folder.py
+++ b/tests/end_to_end/test_e2e_file_and_folder.py
@@ -297,3 +297,27 @@ def test_put_file_with_more_than_one_error():
     assert len(details) == 2
     assert [415, 'File extension not allowed'] in details
     assert [415, 'File mimetype not allowed'] in details
+
+
+@pytest.mark.e2e
+def test_get_file_details_returns_expected_details():
+    headers = token_getter.get_headers()
+    # Upload file with unique filename twice, so we have two versions
+    filename = make_unique_name("save_path_file.txt")
+    upload_file = test_md_file.get_data(filename)
+    _ = post_a_file(url=HOST_URL, headers=headers, file_data=upload_file)
+    _ = post_a_file(url=HOST_URL, headers=headers, file_data=upload_file)
+    # Get the file's details
+    response = client.get(f"{HOST_URL}/get_file_details",
+                          headers=headers,
+                          params={"file_key": filename})
+    json_details = response.json()
+
+    assert response.status_code == 200
+    assert "version_history" in json_details
+    version_history = json_details.get("version_history")
+    assert len(version_history) == 2  # We have two versions
+    assert version_history[0]["Key"] == version_history[1]["Key"] == filename  # Both versions have same filename/key
+    assert version_history[0]["VersionId"] != version_history[1]["VersionId"]  # Both versions have different VersionID
+    assert version_history[0]["IsLatest"] is True  # First version returned is the "latest"
+    assert version_history[1]["IsLatest"] is False  # Second version returned is not the "latest"

--- a/tests/fixtures/casbin_policy_allow_test_user.csv
+++ b/tests/fixtures/casbin_policy_allow_test_user.csv
@@ -9,6 +9,7 @@ p, test_user, /available_validators, GET
 
 p, test_user, /retrieve_file, GET
 p, test_user, /retrieve_file/, GET
+p, test_user, /get_file_details, GET
 p, test_user, /save_or_update_file, PUT
 p, test_user, /save_file, POST
 p, test_user, /bulk_upload, PUT

--- a/tests/routers/test_get_file_details.py
+++ b/tests/routers/test_get_file_details.py
@@ -1,0 +1,63 @@
+
+import datetime
+from unittest.mock import patch
+# test_client is fixture defined in tests/fixtures/auth.py
+# audit_service_mock is fixture defined in tests/fixtues/audit.py
+
+
+def test_get_file_details_missing_key(test_client, audit_service_mock):
+    response = test_client.get('/get_file_details')
+    assert response.status_code == 400
+    assert 'detail' in response.json()
+    assert response.json()['detail'] == 'File key is missing'
+
+
+def test_get_file_details_file_not_found(test_client, audit_service_mock):
+    file_key = 'missing_file.txt'
+    with patch("src.routers.file_details.list_file_versions", return_value=[]):
+        response = test_client.get('/get_file_details', params={"file_key": file_key})
+    assert response.status_code == 404
+    assert response.json()['detail'] == f"No details found for file: {file_key}"
+    audit_service_mock.assert_called()
+
+
+def test_get_file_details_returns_expected_details_with_1_version(test_client, audit_service_mock):
+    file_key = 'file_with_one_version.txt'
+
+    s3_version_details = [{"Key": file_key, "VersionId": "abc123", "IsLatest": True,
+                           "Size": 120, "LastModified": datetime.datetime(2026, 4, 27, 12, 30, 45),
+                           "SecretThing": "Shhh!"}]
+
+    # Subset of returned results - only includes keys: Key, VersionId, IsLatest, Size and LastModified
+    # Anything else excluded (also LastModified is now str, not datetime)
+    expected_result = {"version_history": [{"Key": file_key, "VersionId": "abc123",
+                                            "IsLatest": True, "Size": 120, "LastModified": "2026-04-27T12:30:45"}]}
+
+    with patch("src.routers.file_details.list_file_versions", return_value=s3_version_details):
+        response = test_client.get('/get_file_details', params={"file_key": file_key})
+    assert response.status_code == 200
+    assert response.json() == expected_result
+    audit_service_mock.assert_called()
+
+
+def test_get_file_details_returns_expected_details_with_2_versions(test_client, audit_service_mock):
+    file_key = 'file_with_two_versions.txt'
+
+    s3_version_details = [
+        {"Key": file_key, "VersionId": "xyz456", "IsLatest": True,
+         "Size": 240, "LastModified": datetime.datetime(2026, 4, 27, 12, 30, 45),
+         "SecretThing": "Shhh!"},
+        {"Key": file_key, "VersionId": "abc123", "IsLatest": False,
+         "Size": 120, "LastModified": datetime.datetime(2026, 3, 20, 11, 29, 44),
+         "SecretThing": "Hush!"}]
+
+    expected_result = {"version_history": [{"Key": file_key, "VersionId": "xyz456", "IsLatest": True,
+                                            "Size": 240, "LastModified": "2026-04-27T12:30:45"},
+                                           {"Key": file_key, "VersionId": "abc123", "IsLatest": False,
+                                           "Size": 120, "LastModified": "2026-03-20T11:29:44"}]}
+
+    with patch("src.routers.file_details.list_file_versions", return_value=s3_version_details):
+        response = test_client.get('/get_file_details', params={"file_key": file_key})
+    assert response.status_code == 200
+    assert response.json() == expected_result
+    audit_service_mock.assert_called()


### PR DESCRIPTION
## Description of change
New endpoint `get_file_details`  that takes file key as parameter and returns version details about the specified file.


Relatively simple to do because our S3 Service has existing function `list_file_versions` that returns version details. New router uses this but returns a subset of details:  `Key`, `VersionID`, `IsLatest`, `Size` and `LastModified`. This is both to remove confusing values and to avoid exposing anything else the underlying AWS S3 Client `list_object_versions` call might include. Results are like the below:

```
{"version_history[
{"Key":"README.md","VersionId":"AZ3SvD1OyHrqiEy8d62hr1457OCHSaCl","IsLatest":true,"Size":17,"LastModified":"2026-04-28T06:33:55+00:00"},
{"Key":"README.md","VersionId":"AZ3SvDxvVWsW2TbYt5Pt7f9Ly69dNJFg","IsLatest":false,"Size":26,"LastModified":"2026-04-28T06:17:24+00:00"}]}
```
### Audit Table
When `get_file_details` is used, this is logged to the audit table using new operation type `INFO`. 

### Client Config
This change required an update to client configs to enable new endpoint to be used. This was done in following PR in the configs repo: https://github.com/ministryofjustice/laa-secure-document-storage-configs/pull/9 for our team's `laa-sds` client.

<!-- Description of the changes made -->

## Link to Jira Ticket

- [SDS-242](https://dsdmoj.atlassian.net/browse/SDS-242)

## Screenshots or test evidence if applicable

<!-- Any evidence of change working -->

### README.md in dev has a lot of versions!
Perhaps unsurprisingly, the README.md file in our dev environment has quite a few versions!

<img width="1191" height="565" alt="image" src="https://github.com/user-attachments/assets/823e5033-375b-4d31-9777-41096208d007" />

###  When specified file does not exist
<img width="820" height="215" alt="image" src="https://github.com/user-attachments/assets/6b0a4957-01a9-469a-bf9f-258e5c620e1f" />


### Audit Table Records
Audit table rows for  failed and successful use of `get_file_details` in dev environment
<img width="1847" height="294" alt="image" src="https://github.com/user-attachments/assets/0dfdf6e9-7291-4050-8c6b-b572b5154f9d" />

### Router docstring in API docs
<img width="1451" height="217" alt="image" src="https://github.com/user-attachments/assets/0a66d447-91ca-42c2-82fc-b18941d09df9" />



[SDS-242]: https://dsdmoj.atlassian.net/browse/SDS-242?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ