### PR TITLE
SDS-244 - Update client-configured validation to handle "fail" results in a similar way to mandatory validation.

### DIFF
--- a/src/handlers/file_upload_handler.py
+++ b/src/handlers/file_upload_handler.py
@@ -106,10 +106,9 @@ async def run_initial_file_checks(request: Request,
 
     # Client-specific validation
     if not error_status:
-        try:
-            await client_configured_validator.validate_or_error(file, client_config.file_validators)
-        except HTTPException as e:
-            error_status = (e.status_code, e.detail)
+        status_code, detail = await client_configured_validator.validate_file(file, client_config.file_validators)
+        if status_code != 200:
+            error_status = (status_code, detail)
 
     # Get checksum from file
     checksum = ""

--- a/src/routers/bulk_upload.py
+++ b/src/routers/bulk_upload.py
@@ -7,7 +7,7 @@ from src.models.client_config import ClientConfig
 from src.models.file_upload import FileUpload, BulkUploadFileResponse
 from src.utils.request_types import RequestType
 from src.handlers.file_upload_handler import handle_file_upload_logic
-from src.validation.client_configured_validator import validate_or_error_file_collection
+from src.validation.client_configured_validator import validate_file_collection
 
 router = APIRouter()
 logger = structlog.get_logger()
@@ -72,8 +72,10 @@ async def bulk_upload(
     """
     # Not included validation for empty files list because Fast API gives 422 error automatically
 
-    # File-collection validation - raises HTTP Exception if validation fails
-    _ = await validate_or_error_file_collection(files, client_config.file_collection_validators)
+    # File-collection validation - raise HTTP Exception on failure
+    validation_outcome = await validate_file_collection(files, client_config.file_collection_validators)
+    if validation_outcome != (200, ""):
+        raise HTTPException(status_code=validation_outcome[0], detail=validation_outcome[1])
 
     # Create dictionary for storing results for each filename supplied
     results = {f.filename: BulkUploadFileResponse(filename=f.filename, positions=[], outcomes=[], ) for f in files}

--- a/src/validation/client_configured_validator.py
+++ b/src/validation/client_configured_validator.py
@@ -110,16 +110,24 @@ async def validate_file(file_object: UploadFile, validator_specs: list[FileValid
 
 
 async def validate_file_collection(files: list[UploadFile],
-                                   validator_specs: list[FileCollectionValidatorSpec]) -> list[tuple[int, str]]:
+                                   validator_specs: list[FileCollectionValidatorSpec]) -> list[tuple[int, str | list]]:
     """
-    Validates the list of file objects against a list of validators, returning [(200, "") if all validators pass.
+    Validates the list of file objects against a list of validators.
 
-    Validators are executed in the provided order, any exception raised during execution of a validator
-    will be logged and returned as an internal error (500, "Internal error handling file").
+    Missing file list
+    List of files is required. When missing returns: (400, "List of files is required")
 
-    Behaviour upon validator failure depends on the validator's continue_to_next_validator_on_fail attribute.
-    When True, validation will proceed to the next validator in sequence. When False, the validation
-    sequence ends and currently accumulated results returned.
+    When All Validators Pass
+    If all validators pass, returns: (200, "")
+
+    Validator Fail and/or Unexpected Exception
+    Validators are executed in the provided order. Behaviour upon validator failure (or unexpected exception)
+    depends on the validator's continue_to_next_validator_on_fail attribute. When True, validation will proceed
+    to the next validator in sequence. When False, the validation sequence ends and currently accumulated results
+    are returned.
+
+    Fail results are returned as a tuple of "headline" status code and list of individual status codes and
+    error details, e.g. (422, [(422, "Too many files"), (422, "Combined file size exceeds limit")])
     """
     if not files:
         return [400, [(400, "List of files is required")]]

--- a/src/validation/client_configured_validator.py
+++ b/src/validation/client_configured_validator.py
@@ -2,7 +2,7 @@ import inspect
 from typing import Any, Dict
 
 import structlog
-from fastapi import HTTPException, UploadFile
+from fastapi import UploadFile
 
 from src.models.file_validator_spec import FileValidatorSpec, FileCollectionValidatorSpec
 from src.validation.file_validator import FileValidator, ValidatorNotFoundError
@@ -123,8 +123,14 @@ async def validate_file_collection(files: list[UploadFile],
     """
     if not files:
         return [400, [(400, "List of files is required")]]
+
     result = await validate(files, validator_specs)
-    return result
+
+    if result == [(200, "")]:
+        return (200, "")
+    else:
+        status_code = get_status_code_for_response(result)
+        return status_code, result
 
 
 async def validate(validation_target: UploadFile | list[UploadFile],
@@ -179,16 +185,3 @@ def get_status_code_for_response(validation_results: list[tuple[int, str]]) -> i
         if 500 in unique_codes:
             status_code = 500
     return status_code
-
-
-async def validate_or_error_file_collection(files: list[UploadFile],
-                                            validators: list[FileCollectionValidatorSpec]) -> tuple[int, str]:
-    """
-    Validates a list of file objects against a list of validators, returning (200, "") if all validators pass,
-    or raise an HTTPException with relevant status_code and detail if one or more validators failed.
-    """
-    results = await validate_file_collection(files, validators)
-    if results != [(200, "")]:
-        status_code = get_status_code_for_response(results)
-        raise HTTPException(status_code=status_code, detail=results)
-    return 200, ""

--- a/src/validation/client_configured_validator.py
+++ b/src/validation/client_configured_validator.py
@@ -79,14 +79,23 @@ def get_kwargs_for_filevalidator(validator: str | FileValidator) -> Dict[str, An
 
 async def validate_file(file_object: UploadFile, validator_specs: list[FileValidatorSpec]) -> tuple[int, str | list]:
     """
-    Validates the file object against a list of validators, returning (200, "") if all validators pass.
+    Validates the file object against a list of validators,
 
-    Validators are executed in the provided order, any exception raised during execution of a validator
-    will be logged and returned as an internal error (500, "Internal error handling file").
+    Missing File
+    File object is required. When missing returns: (400, "File is required)
 
-    Behaviour upon validator failure depends on the validator's continue_to_next_validator_on_fail attribute.
-    When True, validation will proceed to the next validator in sequence. When False, the validation
-    sequence ends and currently accumulated results returned.
+    When All Validators Pass
+    If all validators pass, returns: (200, "")
+
+    Validator Fail and/or Unexpected Exception
+    Validators are executed in the provided order. Behaviour upon validator failure (or unexpected exception)
+    depends on the validator's continue_to_next_validator_on_fail attribute. When True, validation will proceed
+    to the next validator in sequence. When False, the validation sequence ends and currently accumulated results
+    are returned.
+
+    Fail results are returned as a tuple of "headline" status code and list of individual status codes and
+    error details, e.g. (500, [(415, "File extension not allowed"), (415, "File mimetype not allowed"),
+                               (500, "Infernal Server Error")])
     """
     if file_object is None or not file_object.filename:
         return 400, "File is required"

--- a/src/validation/client_configured_validator.py
+++ b/src/validation/client_configured_validator.py
@@ -77,9 +77,9 @@ def get_kwargs_for_filevalidator(validator: str | FileValidator) -> Dict[str, An
     return validator_kwargs
 
 
-async def validate_file(file_object: UploadFile, validator_specs: list[FileValidatorSpec]) -> list[tuple[int, str]]:
+async def validate_file(file_object: UploadFile, validator_specs: list[FileValidatorSpec]) -> tuple[int, str | list]:
     """
-    Validates the file object against a list of validators, returning [(200, "") if all validators pass.
+    Validates the file object against a list of validators, returning (200, "") if all validators pass.
 
     Validators are executed in the provided order, any exception raised during execution of a validator
     will be logged and returned as an internal error (500, "Internal error handling file").
@@ -89,9 +89,15 @@ async def validate_file(file_object: UploadFile, validator_specs: list[FileValid
     sequence ends and currently accumulated results returned.
     """
     if file_object is None or not file_object.filename:
-        return [400, [(400, "File is required")]]
+        return 400, "File is required"
+
     result = await validate(file_object, validator_specs)
-    return result
+
+    if result == [(200, "")]:
+        return (200, "")
+    else:
+        status_code = get_status_code_for_response(result)
+        return status_code, result
 
 
 async def validate_file_collection(files: list[UploadFile],
@@ -164,22 +170,6 @@ def get_status_code_for_response(validation_results: list[tuple[int, str]]) -> i
         if 500 in unique_codes:
             status_code = 500
     return status_code
-
-
-async def validate_or_error(file_object, validators: list[FileValidatorSpec]) -> tuple[int, str]:
-    """
-    Validates the file object against a list of validators, returning (200, "") if all validators pass,
-    or raise an HTTPException with relevant status_code and detail if one or more validators failed.
-
-    :param validators:
-    :param file_object:
-    :return: status_code: int, detail: str
-    """
-    results = await validate_file(file_object, validators)
-    if results != [(200, "")]:
-        status_code = get_status_code_for_response(results)
-        raise HTTPException(status_code=status_code, detail=results)
-    return 200, ""
 
 
 async def validate_or_error_file_collection(files: list[UploadFile],

--- a/tests/handlers/test_file_upload_handler.py
+++ b/tests/handlers/test_file_upload_handler.py
@@ -29,11 +29,11 @@ from src.utils.request_types import RequestType
 @patch("src.handlers.file_upload_handler.s3_service.save", return_value=True)
 @patch("src.handlers.file_upload_handler.s3_service.file_exists")
 @patch("src.handlers.file_upload_handler.audit_service.put_item")
-@patch("src.handlers.file_upload_handler.client_configured_validator.validate_or_error")
+@patch("src.handlers.file_upload_handler.client_configured_validator.validate_file", return_value=(200, ""))
 @patch("src.handlers.file_upload_handler.run_mandatory_validators", return_value=(200, ""))
 async def test_handle_file_upload_success(
     mandatory_validators_mock,
-    validate_or_error_mock,
+    validate_file_mock,
     audit_put_item_mock,
     file_exists_mock,
     save_mock,
@@ -70,7 +70,7 @@ async def test_handle_file_upload_success(
     audit_put_item_mock.assert_called_once()
     save_mock.assert_called_once()
     mandatory_validators_mock.assert_called_once()
-    validate_or_error_mock.assert_called_once()
+    validate_file_mock.assert_called_once()
     file_exists_mock.assert_called_once()
     get_file_checksum_mock.assert_called_once()
 
@@ -80,11 +80,11 @@ async def test_handle_file_upload_success(
 @pytest.mark.asyncio
 @patch("src.handlers.file_upload_handler.s3_service.file_exists", return_value=True)
 @patch("src.handlers.file_upload_handler.audit_service.put_item")
-@patch("src.handlers.file_upload_handler.client_configured_validator.validate_or_error")
+@patch("src.handlers.file_upload_handler.client_configured_validator.validate_file", return_value=(200, ""))
 @patch("src.handlers.file_upload_handler.run_mandatory_validators", return_value=(200, ""))
 async def test_handle_file_upload_POST_existing_file_failure(
     mandatory_validators_mock,
-    validate_or_error_mock,
+    validate_file_mock,
     audit_put_item_mock,
     file_exists_mock
 ):
@@ -110,7 +110,7 @@ async def test_handle_file_upload_POST_existing_file_failure(
     assert exc_info.value.status_code == 409
     assert f"File {file.filename} already exists and cannot be overwritten" in str(exc_info.value.detail)
     mandatory_validators_mock.assert_called_once()
-    validate_or_error_mock.assert_called_once()
+    validate_file_mock.assert_called_once()
     file_exists_mock.assert_called_once()
 
 
@@ -182,11 +182,11 @@ async def test_handle_file_upload_antivirus_unexpected_result(mandatory_validato
 @patch("src.handlers.file_upload_handler.s3_service.save", return_value=False)
 @patch("src.handlers.file_upload_handler.s3_service.file_exists", return_value=False)
 @patch("src.handlers.file_upload_handler.audit_service.put_item")
-@patch("src.handlers.file_upload_handler.client_configured_validator.validate_or_error")
+@patch("src.handlers.file_upload_handler.client_configured_validator.validate_file", return_value=(200, ""))
 @patch("src.handlers.file_upload_handler.run_mandatory_validators", return_value=(200, ""))
 async def test_handle_file_upload_save_failure(
     mandatory_validators_mock,
-    validate_or_error_mock,
+    validate_file_mock,
     audit_put_item_mock,
     file_exists_mock,
     save_mock
@@ -216,7 +216,7 @@ async def test_handle_file_upload_save_failure(
     assert "failed to save" in str(exc_info.value.detail)
 
     mandatory_validators_mock.assert_called_once()
-    validate_or_error_mock.assert_called_once()
+    validate_file_mock.assert_called_once()
     audit_put_item_mock.assert_called_once()
     save_mock.assert_called_once()
     file_exists_mock.assert_called_once()
@@ -224,12 +224,12 @@ async def test_handle_file_upload_save_failure(
 
 @pytest.mark.asyncio
 @patch("src.handlers.file_upload_handler.get_file_checksum", return_value=("", "Unexpected error getting checksum"))
-@patch("src.handlers.file_upload_handler.client_configured_validator.validate_or_error")
+@patch("src.handlers.file_upload_handler.client_configured_validator.validate_file", return_value=(200, ""))
 @patch("src.handlers.file_upload_handler.audit_service.put_item")
 @patch("src.handlers.file_upload_handler.run_mandatory_validators", return_value=(200, ""))
 async def test_handle_file_upload_checksum_failure(mandatory_validators_mock,
                                                    audit_put_item_mock,
-                                                   validate_or_error_mock,
+                                                   validate_file_mock,
                                                    get_file_checksum_mock):
 
     request = MagicMock(headers={"x-request-id": "checksum-failure-1", "content-length": 1})

--- a/tests/validation_tests/test_client_configured_validator.py
+++ b/tests/validation_tests/test_client_configured_validator.py
@@ -1,11 +1,8 @@
 import pytest
-from unittest.mock import patch
-from fastapi import HTTPException
 from src.validation.client_configured_validator import generate_all_filevalidatorspecs
 from src.validation.client_configured_validator import get_kwargs_for_filevalidator
 from src.validation.client_configured_validator import get_validator_validate_docstring
 from src.validation.client_configured_validator import get_status_code_for_response
-from src.validation.client_configured_validator import validate_or_error
 from src.validation.file_validator import MaxFileSize, MinFileSize
 from src.validation.file_validator import AllowedFileExtensions, DisallowedFileExtensions
 from src.validation.file_validator import AllowedMimetypes, DisallowedMimetypes
@@ -218,44 +215,3 @@ def test_get_validator_validate_docstring_with_actual_validator():
 def test_get_status_code_from_response(validator_results, expected_result):
     result = get_status_code_for_response(validator_results)
     assert result == expected_result
-
-
-@pytest.mark.asyncio
-async def test_validate_or_error_with_pass():
-    # Note these values don't really matter due to patching of validate return value.
-    # This test concerns the format of result rather than the validation itself
-    file = ""
-    validators = []
-    with patch("src.validation.client_configured_validator.validate_file", return_value=[(200, "")]):
-        result = await validate_or_error(file, validators)
-    assert result == (200, "")
-
-
-# Note this function raises an HTTPException when there is a "fail" result.
-# The expected results here are based on Pytest's ExceptionInfo representation
-# of the exception, not HTTPException directly.
-@pytest.mark.asyncio
-@pytest.mark.parametrize("validate_result,expected_result", [
-    # Single failure
-    ([(400, 'Size is too small')],
-     "400: [(400, 'Size is too small')]"),
-    # Two failures with same status codes
-    ([(415, 'File mimetype not allowed'), (415, 'File extension not allowed')],
-     "415: [(415, 'File mimetype not allowed'), (415, 'File extension not allowed')]"),
-    # Two failures with different status codes - gets 422
-    ([(400, "Size is too small"), (415, "File extension not allowed")],
-     "422: [(400, 'Size is too small'), (415, 'File extension not allowed')]"),
-    # 500 error present
-    ([(400, "Size is too small"), (500, "Infernal Server Error")],
-     "500: [(400, 'Size is too small'), (500, 'Infernal Server Error')]")
-    ])
-async def test_validate_or_error_with_fail(validate_result, expected_result):
-    # Note the fileobject and  validators values  don't really matter due to patching of
-    # validate return value. This test concerns the format of result/exception rather
-    # than validation itself
-    fileobject = ""
-    validators = []
-    with patch("src.validation.client_configured_validator.validate_file", return_value=validate_result):
-        with pytest.raises(HTTPException) as excinfo:
-            _ = await validate_or_error(fileobject, validators)
-    assert str(excinfo.value) == expected_result

--- a/tests/validation_tests/test_client_configured_validator_validation.py
+++ b/tests/validation_tests/test_client_configured_validator_validation.py
@@ -472,12 +472,12 @@ async def test_validate_file_returns_validation_result_when_file_supplied():
     actual validation, which is covered in more detail in other tests, e.g. those of validate.
     """
     myfile = make_uploadfile(b"abcd")
-    mock_return = [(200, "Mock Success")]
+    mock_validate_return = [(200, "")]
     # Because we're patching validate function, file_validator_specs value does not affect outcome
     file_validator_specs = [make_validatorspec("MaxFileSize", size=5), ]
-    with patch("src.validation.client_configured_validator.validate", return_value=mock_return):
+    with patch("src.validation.client_configured_validator.validate", return_value=mock_validate_return):
         result = await validate_file(myfile, file_validator_specs)
-    assert result == mock_return
+    assert result == (200, "")
 
 
 @pytest.mark.asyncio
@@ -493,7 +493,7 @@ async def test_validate_file_returns_error_when_no_file_supplied(badfile):
     file_validator_specs = [make_validatorspec("MaxFileSize", size=5),]
     with patch("src.validation.client_configured_validator.validate", return_value=mock_return):
         result = await validate_file(badfile, file_validator_specs)
-    assert result == [400, [(400, "File is required")]]
+    assert result == (400, "File is required")
 
 
 # validate_file_collection tests

--- a/tests/validation_tests/test_client_configured_validator_validation.py
+++ b/tests/validation_tests/test_client_configured_validator_validation.py
@@ -506,12 +506,12 @@ async def test_validate_file_collection_returns_validation_result_when_collectio
     actual validation, which is covered in more detail in other tests, e.g. those of validate.
     """
     myfiles = [make_uploadfile(b"A"), make_uploadfile(b"B")]
-    mock_return = [(200, "Mock Success")]
+    mock_return = [(200, "")]
     # Because we're patching validate function, file_validator_specs value does not affect outcome
     file_collection_validator_specs = [make_file_collection_validatorspec("MaxFileCount", max_count=5),]
     with patch("src.validation.client_configured_validator.validate", return_value=mock_return):
         result = await validate_file_collection(myfiles, file_collection_validator_specs)
-    assert result == mock_return
+    assert result == (200, "")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description of change

This improves consistency between mandatory validators and client-configured validators. 

Mandatory validation returned status-code and message for both "pass" and "fail" outcomes whereas client-configured validation would only return status-code and message when validators passed but raise an exception when there was a fail (which would subsequently be caught and turned back into status-code and message). This change updates client-configured validation to work in similar way to mandatory validation and return status-code and message for both "pass" and "fail". 

Note this is not intended to make any difference to the responses returned by our endpoints which should be the same as before, regardless of "pass" or "fail".

### Changes to client-configured validator runner
Client-configured validator runner is now modified version of `client_configured_validator.validate_file` rather than `validate_or_error` which has been removed. 
- Runner now just returns "pass" or "fail" result (previously only returned "pass" and raised exception for "fail" which was externally caught and turned back into a message). 
- Some tweaks to the way details are returned but without affecting the actual API responses

These changes make the handling of "fail" results from client-configured validators more consistent with mandatory validators, and also more concise. 

### Changes to file_upload_handler
Client-configured validators are now called in the same way as mandatory validators (but are still separate for now).

### Changes to file collection client-configured validator runner
Similar changes to file collection validation running. File-collection validator runner is now modified version of `validate_file_collection` function rather than `validate_or_error_file_collection` which has been removed.

Note these are run by `bulk_upload` router rather than `file_upload_handler` because they only concern collection of files. `bulk_upload` router updated to raise HTTPException when validation fails. I think this also has the benefit of making error behaviour more explicit from point-of-view of someone looking at this router.

## Link to Jira Ticket

- [SDS-244](https://dsdmoj.atlassian.net/browse/SDS-244)

## Screenshots or test evidence if applicable

<!-- Any evidence of change working -->


### Client-configured validator failure as before
<img width="793" height="402" alt="image" src="https://github.com/user-attachments/assets/119907f6-672d-4614-8e13-19c1b5e29bee" />
Note due to json conversion the `(` `)` brackets from the tuples have become `[` `]` which is existing behaviour.

### File collection validation as before
Note "combined file size" limit needs to be set in client config.
<img width="872" height="531" alt="image" src="https://github.com/user-attachments/assets/9976768d-1e46-4164-ac04-a6af58593b14" />

[SDS-244]: https://dsdmoj.atlassian.net/browse/SDS-244?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ