### PR TITLE
SDS-261 - remove need to specify bucket or body when uploading files

### DIFF
--- a/Postman/SecureDocStoreAPI.postman_collection.json
+++ b/Postman/SecureDocStoreAPI.postman_collection.json
@@ -1,6 +1,6 @@
 {
   "info": {
-    "_postman_id": "459c2be1-5fd2-4e42-940f-f6f3f6c90231",
+    "_postman_id": "4ffad726-44ee-4f24-8002-b4b7c6925f2c",
     "name": "SecureDocStoreAPI",
     "description": "This suite contains integration tests for the Secure Document Storage API. A Pre-request script is configured to ensure all tests resolve a valid auth token should they need it",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
@@ -946,85 +946,6 @@
           "response": []
         },
         {
-          "name": "Save Or Update File With Missing Bucket",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test(\"Status code is 400\", function () {",
-                  "    pm.response.to.have.status(400);",
-                  "});",
-                  "pm.test(\"Response has required fields\", function () {",
-                  "    var responseBody = pm.response.json();",
-                  "    pm.expect(responseBody).to.have.property('detail');",
-                  "    pm.expect(responseBody.detail).to.have.property('bucketName');",
-                  "    pm.expect(responseBody.detail.bucketName).to.eql('Field required');",
-                  "});"
-                ],
-                "type": "text/javascript",
-                "packages": {}
-              }
-            },
-            {
-              "listen": "prerequest",
-              "script": {
-                "exec": [
-                  ""
-                ],
-                "type": "text/javascript",
-                "packages": {}
-              }
-            }
-          ],
-          "request": {
-            "auth": {
-              "type": "bearer",
-              "bearer": [
-                {
-                  "key": "token",
-                  "value": "",
-                  "type": "string"
-                }
-              ]
-            },
-            "method": "PUT",
-            "header": [
-              {
-                "key": "Authorization",
-                "value": "bearer {{bearerToken}}",
-                "type": "text"
-              }
-            ],
-            "body": {
-              "mode": "formdata",
-              "formdata": [
-                {
-                  "key": "file",
-                  "type": "file",
-                  "src": "test_file.md"
-                },
-                {
-                  "key": "body",
-                  "value": "{\"folder\":\"testmult\"} ",
-                  "type": "text"
-                }
-              ]
-            },
-            "url": {
-              "raw": "{{SDSBaseUrl}}/save_or_update_file",
-              "host": [
-                "{{SDSBaseUrl}}"
-              ],
-              "path": [
-                "save_or_update_file"
-              ]
-            },
-            "description": "Expect a 400 BAD REQUEST when no bucket is defined in the save-or-update request"
-          },
-          "response": []
-        },
-        {
           "name": "Save Or Update File Without File",
           "event": [
             {
@@ -1791,85 +1712,6 @@
               ]
             },
             "description": "Expect a 415 UNSUPPORTED MEDIA TYPE when uploading a mock executable file as disallowed by client config."
-          },
-          "response": []
-        },
-        {
-          "name": "Save File With Missing Bucket",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test(\"Status code is 400\", function () {",
-                  "    pm.response.to.have.status(400);",
-                  "});",
-                  "pm.test(\"Response has required fields\", function () {",
-                  "    var responseBody = pm.response.json();",
-                  "    pm.expect(responseBody).to.have.property('detail');",
-                  "    pm.expect(responseBody.detail).to.have.property('bucketName');",
-                  "    pm.expect(responseBody.detail.bucketName).to.eql('Field required');",
-                  "});"
-                ],
-                "type": "text/javascript",
-                "packages": {}
-              }
-            },
-            {
-              "listen": "prerequest",
-              "script": {
-                "exec": [
-                  ""
-                ],
-                "type": "text/javascript",
-                "packages": {}
-              }
-            }
-          ],
-          "request": {
-            "auth": {
-              "type": "bearer",
-              "bearer": [
-                {
-                  "key": "token",
-                  "value": "",
-                  "type": "string"
-                }
-              ]
-            },
-            "method": "POST",
-            "header": [
-              {
-                "key": "Authorization",
-                "value": "bearer {{bearerToken}}",
-                "type": "text"
-              }
-            ],
-            "body": {
-              "mode": "formdata",
-              "formdata": [
-                {
-                  "key": "file",
-                  "type": "file",
-                  "src": "test_file.md"
-                },
-                {
-                  "key": "body",
-                  "value": "{\"folder\":\"testmult\"} ",
-                  "type": "text"
-                }
-              ]
-            },
-            "url": {
-              "raw": "{{SDSBaseUrl}}/save_file",
-              "host": [
-                "{{SDSBaseUrl}}"
-              ],
-              "path": [
-                "save_file"
-              ]
-            },
-            "description": "Expect a 400 BAD REQUEST when no bucket is defined in the save request"
           },
           "response": []
         },

--- a/src/handlers/file_upload_handler.py
+++ b/src/handlers/file_upload_handler.py
@@ -20,20 +20,20 @@ logger = structlog.get_logger()
 async def handle_file_upload_logic(
     request: Request,
     file: Optional[UploadFile],
-    body: FileUpload,
     client_config: ClientConfig,
     request_type: RequestType,
+    body: Optional[FileUpload] = None,
     filename_position: int = 0
 ) -> Tuple[Dict, bool]:
+    if body is None:
+        body = FileUpload()
     # Bucket check
     metadata = body.model_dump() or {}
     bucket_name = metadata.pop("bucketName", None)
-    if bucket_name != client_config.bucket_name:
-        # For compatibility we allow the bucket name to be specified in the request,
-        # but log a warning to help prevent confusion
+    if bucket_name:
         logger.warning(
-            f"{client_config.azure_client_id} specified {bucket_name}, "
-            f"not configured name {client_config.bucket_name}"
+            f"{client_config.azure_client_id} specified bucked name: {bucket_name}, "
+            f"but we no longer expect this to be included in requests."
         )
 
     # Initial file checks - virus scan, mandatory validators, client config validators ...

--- a/src/handlers/file_upload_handler.py
+++ b/src/handlers/file_upload_handler.py
@@ -27,20 +27,11 @@ async def handle_file_upload_logic(
 ) -> Tuple[Dict, bool]:
     if body is None:
         body = FileUpload()
-    # Check for obsolete bucket name value in body
-    # We used to accept a bucket name value from request body but now only use bucket name from
-    # client_config. Record warning message when bucket name found in body.
-    metadata = body.model_dump() or {}
-    redundant_bucket_name = metadata.pop("bucketName", None)
-    if redundant_bucket_name:
-        logger.warning(
-            f"{client_config.azure_client_id} specified bucked name: {redundant_bucket_name}, "
-            f"but we no longer expect this to be included in requests."
-        )
 
     # Initial file checks - virus scan, mandatory validators, client config validators ...
     checksum, error_status = await run_initial_file_checks(request, file, client_config)
 
+    metadata = body.model_dump() or {}
     folder_prefix = metadata.pop("folder", "")
     full_filename = os.path.join(folder_prefix, file.filename) if folder_prefix else file.filename
 

--- a/src/handlers/file_upload_handler.py
+++ b/src/handlers/file_upload_handler.py
@@ -27,12 +27,14 @@ async def handle_file_upload_logic(
 ) -> Tuple[Dict, bool]:
     if body is None:
         body = FileUpload()
-    # Bucket check
+    # Check for obsolete bucket name value in body
+    # We used to accept a bucket name value from request body but now only use bucket name from
+    # client_config. Record warning message when bucket name found in body.
     metadata = body.model_dump() or {}
-    bucket_name = metadata.pop("bucketName", None)
-    if bucket_name:
+    redundant_bucket_name = metadata.pop("bucketName", None)
+    if redundant_bucket_name:
         logger.warning(
-            f"{client_config.azure_client_id} specified bucked name: {bucket_name}, "
+            f"{client_config.azure_client_id} specified bucked name: {redundant_bucket_name}, "
             f"but we no longer expect this to be included in requests."
         )
 

--- a/src/models/file_upload.py
+++ b/src/models/file_upload.py
@@ -4,7 +4,6 @@ from pydantic import BaseModel
 
 
 class FileUpload(BaseModel):
-    bucketName: str
     folder: Optional[str] = None
 
 

--- a/src/routers/bulk_upload.py
+++ b/src/routers/bulk_upload.py
@@ -1,8 +1,9 @@
 import structlog
+from typing import Optional
+
 from fastapi import APIRouter, Depends, UploadFile, Request, HTTPException
 
 from src.middleware.client_config_middleware import client_config_middleware
-from src.validation.json_validator import validate_json
 from src.models.client_config import ClientConfig
 from src.models.file_upload import FileUpload, BulkUploadFileResponse
 from src.utils.request_types import RequestType
@@ -17,7 +18,7 @@ logger = structlog.get_logger()
 async def bulk_upload(
     request: Request,
     files: list[UploadFile],
-    body: FileUpload = Depends(validate_json(FileUpload)),
+    body: Optional[FileUpload] = None,
     client_config: ClientConfig = Depends(client_config_middleware)
     # Ugly formating of line below is to keep flake8 happy
 ) -> dict[str, BulkUploadFileResponse]:

--- a/src/routers/bulk_upload.py
+++ b/src/routers/bulk_upload.py
@@ -1,9 +1,8 @@
 import structlog
-from typing import Optional
-
 from fastapi import APIRouter, Depends, UploadFile, Request, HTTPException
 
 from src.middleware.client_config_middleware import client_config_middleware
+from src.validation.json_validator import validate_optional_body_json
 from src.models.client_config import ClientConfig
 from src.models.file_upload import FileUpload, BulkUploadFileResponse
 from src.utils.request_types import RequestType
@@ -18,7 +17,7 @@ logger = structlog.get_logger()
 async def bulk_upload(
     request: Request,
     files: list[UploadFile],
-    body: Optional[FileUpload] = None,
+    body: FileUpload = Depends(validate_optional_body_json(FileUpload)),
     client_config: ClientConfig = Depends(client_config_middleware)
     # Ugly formating of line below is to keep flake8 happy
 ) -> dict[str, BulkUploadFileResponse]:

--- a/src/routers/save_file.py
+++ b/src/routers/save_file.py
@@ -5,6 +5,7 @@ from fastapi import APIRouter, UploadFile, Depends, Request
 from fastapi.responses import JSONResponse
 
 from src.middleware.client_config_middleware import client_config_middleware
+from src.validation.json_validator import validate_optional_body_json
 from src.models.client_config import ClientConfig
 from src.models.file_upload import FileUpload
 from src.utils.request_types import RequestType
@@ -19,7 +20,7 @@ logger = structlog.get_logger()
 async def save_file(
     request: Request,
     file: Optional[UploadFile] = None,
-    body: Optional[FileUpload] = None,
+    body: FileUpload = Depends(validate_optional_body_json(FileUpload)),
     client_config: ClientConfig = Depends(client_config_middleware),
 ):
     """

--- a/src/routers/save_file.py
+++ b/src/routers/save_file.py
@@ -7,7 +7,6 @@ from fastapi.responses import JSONResponse
 from src.middleware.client_config_middleware import client_config_middleware
 from src.models.client_config import ClientConfig
 from src.models.file_upload import FileUpload
-from src.validation.json_validator import validate_json
 from src.utils.request_types import RequestType
 from src.handlers.file_upload_handler import handle_file_upload_logic
 
@@ -20,7 +19,7 @@ logger = structlog.get_logger()
 async def save_file(
     request: Request,
     file: Optional[UploadFile] = None,
-    body: FileUpload = Depends(validate_json(FileUpload)),
+    body: Optional[FileUpload] = None,
     client_config: ClientConfig = Depends(client_config_middleware),
 ):
     """

--- a/src/routers/save_or_update_file.py
+++ b/src/routers/save_or_update_file.py
@@ -42,8 +42,6 @@ async def save_or_update_file(
     if file is None:
         file = UploadFile(file=None, filename="")
 
-    logger.info(f"####### {body}")
-
     response, file_existed = await handle_file_upload_logic(
         request=request,
         file=file,

--- a/src/routers/save_or_update_file.py
+++ b/src/routers/save_or_update_file.py
@@ -5,7 +5,6 @@ from fastapi import APIRouter, UploadFile, Depends, Request
 from fastapi.responses import JSONResponse
 
 from src.middleware.client_config_middleware import client_config_middleware
-from src.validation.json_validator import validate_json
 from src.models.client_config import ClientConfig
 from src.models.file_upload import FileUpload
 from src.utils.request_types import RequestType
@@ -20,7 +19,7 @@ logger = structlog.get_logger()
 async def save_or_update_file(
     request: Request,
     file: Optional[UploadFile] = None,
-    body: FileUpload = Depends(validate_json(FileUpload)),
+    body: Optional[FileUpload] = None,
     client_config: ClientConfig = Depends(client_config_middleware),
 ):
     """

--- a/src/routers/save_or_update_file.py
+++ b/src/routers/save_or_update_file.py
@@ -5,6 +5,7 @@ from fastapi import APIRouter, UploadFile, Depends, Request
 from fastapi.responses import JSONResponse
 
 from src.middleware.client_config_middleware import client_config_middleware
+from src.validation.json_validator import validate_optional_body_json
 from src.models.client_config import ClientConfig
 from src.models.file_upload import FileUpload
 from src.utils.request_types import RequestType
@@ -19,7 +20,7 @@ logger = structlog.get_logger()
 async def save_or_update_file(
     request: Request,
     file: Optional[UploadFile] = None,
-    body: Optional[FileUpload] = None,
+    body: FileUpload = Depends(validate_optional_body_json(FileUpload)),
     client_config: ClientConfig = Depends(client_config_middleware),
 ):
     """
@@ -40,6 +41,8 @@ async def save_or_update_file(
     """
     if file is None:
         file = UploadFile(file=None, filename="")
+
+    logger.info(f"####### {body}")
 
     response, file_existed = await handle_file_upload_logic(
         request=request,

--- a/src/validation/json_validator.py
+++ b/src/validation/json_validator.py
@@ -1,10 +1,29 @@
 from pydantic import BaseModel, ValidationError
 from fastapi import HTTPException, Form
 from typing import Type
+import structlog
+
+logger = structlog.get_logger()
 
 
 def validate_json(model: Type[BaseModel]):
     def wrapper(body: str = Form(...)):
+        try:
+            return model.model_validate_json(body)
+        except ValidationError as exc:
+            # error['loc'] is a tuple which can be empty. Can't use this tuple as key in our data extract because
+            # it breaks later json encoding. Using comma-separated string representation of the tuple's contents as
+            # key in error_details.
+            error_details = {",".join(str(e) for e in error['loc']): error['msg']
+                             for error in exc.errors()}
+            raise HTTPException(status_code=400, detail=error_details)
+
+    return wrapper
+
+
+def validate_optional_body_json(model: Type[BaseModel]):
+    # Care with quotation marks for default value - need " within the string to avoid `Invalid JSON`
+    def wrapper(body: str = Form(default='{"body": "{}"}')):
         try:
             return model.model_validate_json(body)
         except ValidationError as exc:

--- a/src/validation/json_validator.py
+++ b/src/validation/json_validator.py
@@ -19,6 +19,11 @@ def validate_json(model: Type[BaseModel]):
 
 
 def validate_optional_body_json(model: Type[BaseModel]):
+    """
+    This function is intended to process optional body data received by file upload
+    routers. The wrapped function returned includes default body parameter that's
+    used when no body included in client's request.
+    """
     # Care with quotation marks for default value - need " within the string to avoid `Invalid JSON`
     def wrapper(body: str = Form(default='{"body": "{}"}')):
         try:

--- a/src/validation/json_validator.py
+++ b/src/validation/json_validator.py
@@ -1,9 +1,6 @@
 from pydantic import BaseModel, ValidationError
 from fastapi import HTTPException, Form
 from typing import Type
-import structlog
-
-logger = structlog.get_logger()
 
 
 def validate_json(model: Type[BaseModel]):

--- a/tests/end_to_end/e2e_helpers.py
+++ b/tests/end_to_end/e2e_helpers.py
@@ -196,6 +196,7 @@ def get_host_url() -> str:
 
 
 def get_upload_body() -> dict[str, dict[str, str]]:
+    "This is now obsolete as bucketName is no longer required when uploading a file"
     return {"body": '{"bucketName": "sds-local"}'}
 
 

--- a/tests/end_to_end/test_e2e.py
+++ b/tests/end_to_end/test_e2e.py
@@ -6,7 +6,6 @@ import httpx as client
 from tests.end_to_end.e2e_helpers import UploadFileData
 from tests.end_to_end.e2e_helpers import get_token_manager
 from tests.end_to_end.e2e_helpers import get_host_url
-from tests.end_to_end.e2e_helpers import get_upload_body
 from tests.end_to_end.e2e_helpers import make_unique_name
 from tests.end_to_end.e2e_helpers import AuditDynamoDBClient
 
@@ -29,7 +28,6 @@ Environment Variables
 """
 
 HOST_URL = get_host_url()
-UPLOAD_BODY = get_upload_body()
 token_getter = get_token_manager()
 
 
@@ -186,8 +184,7 @@ def test_put_new_file_once():
 
     response = client.put(f"{HOST_URL}/save_or_update_file",
                           headers=token_getter.get_headers(),
-                          files=upload_file,
-                          data=UPLOAD_BODY)
+                          files=upload_file)
 
     details = response.json()
     assert response.status_code == 201
@@ -197,22 +194,36 @@ def test_put_new_file_once():
 
 
 @pytest.mark.e2e
+def test_put_file_with_folder_specified_in_body_saves_to_that_folder():
+    new_filename = make_unique_name("put_new_file_test.txt")
+    upload_file = test_md_file.get_data(new_filename)
+    # Care with formatting the below - value needs to be str, with " inside
+    data = {"body": '{"folder": "my_test_folder"}'}
+    response = client.put(f"{HOST_URL}/save_or_update_file",
+                          headers=token_getter.get_headers(),
+                          files=upload_file,
+                          data=data)
+
+    assert response.status_code == 201
+    # Folder "my_test_folder" from request body is included in success message
+    assert f"File saved successfully in sds-local with key my_test_folder/{new_filename}" in response.text
+
+
+@pytest.mark.e2e
 def test_put_new_file_twice_gives_expected_code_and_message():
     new_filename = make_unique_name("loaded_twice.txt")
     upload_file = test_md_file.get_data(new_filename)
 
     response1 = client.put(f"{HOST_URL}/save_or_update_file",
                            headers=token_getter.get_headers(),
-                           files=upload_file,
-                           data=UPLOAD_BODY)
+                           files=upload_file)
 
     # This resets the "seek" position to start of file, to prevent 0-byte upload
     upload_file = test_md_file.get_data(new_filename)
 
     response2 = client.put(f"{HOST_URL}/save_or_update_file",
                            headers=token_getter.get_headers(),
-                           files=upload_file,
-                           data=UPLOAD_BODY)
+                           files=upload_file)
 
     assert response1.status_code == 201 and str(response1.text).startswith('{"success":"File saved successfully')
     assert response2.status_code == 200 and str(response2.text).startswith('{"success":"File updated successfully')
@@ -233,8 +244,7 @@ def test_put_file_with_virus_is_blocked():
     upload_virus_file = virus_file.get_data()
     response = client.put(f"{HOST_URL}/save_or_update_file",
                           headers=token_getter.get_headers(),
-                          files=upload_virus_file,
-                          data=UPLOAD_BODY)
+                          files=upload_virus_file)
     assert response.status_code == 400
     assert response.json()["detail"] == "Virus Found"
 
@@ -244,32 +254,16 @@ def test_put_file_with_disallowed_file_type_is_blocked():
     upload_disallowed_file = disallowed_file.get_data()
     response = client.put(f"{HOST_URL}/save_or_update_file",
                           headers=token_getter.get_headers(),
-                          files=upload_disallowed_file,
-                          data=UPLOAD_BODY)
+                          files=upload_disallowed_file)
     assert response.status_code == 415
     assert response.json()["detail"] == [[415, "File mimetype not allowed"]]
 
 
 @pytest.mark.e2e
-def test_put_file_with_missing_bucket_is_blocked():
-    new_filename = make_unique_name("put_new_file_test.txt")
-    upload_file = test_md_file.get_data(new_filename)
-    # Care with formatting the below - value needs to be str, delimted with '
-    # (Although this is just creating a body that lacks bucketName)
-    data = {"body": '{"folder": "testmult"}'}
-    response = client.put(f"{HOST_URL}/save_or_update_file",
-                          headers=token_getter.get_headers(),
-                          files=upload_file,
-                          data=data)
-    assert response.status_code == 400
-    assert response.json()["detail"]["bucketName"] == "Field required"
-
-
-@pytest.mark.e2e
 def test_put_file_without_file_fails_as_expected():
     response = client.put(f"{HOST_URL}/save_or_update_file",
-                          headers=token_getter.get_headers(),
-                          data=UPLOAD_BODY)
+                          headers=token_getter.get_headers()
+                          )
     assert response.status_code == 400
     assert response.json()["detail"] == "File is required"
 
@@ -335,8 +329,7 @@ def test_post_new_file_once_is_successful():
 
     response = client.post(f"{HOST_URL}/save_file",
                            headers=token_getter.get_headers(),
-                           files=upload_file,
-                           data=UPLOAD_BODY)
+                           files=upload_file)
 
     details = response.json()
     assert response.status_code == 201
@@ -346,19 +339,28 @@ def test_post_new_file_once_is_successful():
 
 
 @pytest.mark.e2e
+def test_post_file_with_folder_specified_in_body_saves_to_that_folder():
+    new_filename = make_unique_name("post_new_file_test.txt")
+    upload_file = test_md_file.get_data(new_filename)
+    # Care with formatting the below - value needs to be str, with " inside
+    data = {"body": '{"folder": "my_other_test_folder"}'}
+    response = client.post(f"{HOST_URL}/save_file", headers=token_getter.get_headers(), files=upload_file, data=data)
+    assert response.status_code == 201
+    assert f"File saved successfully in sds-local with key my_other_test_folder/{new_filename}" in response.text
+
+
+@pytest.mark.e2e
 def test_post_new_file_second_time_fails():
     new_filename = make_unique_name("post_new_file_test.txt")
     upload_file = test_md_file.get_data(new_filename)
 
     response1 = client.post(f"{HOST_URL}/save_file",
                             headers=token_getter.get_headers(),
-                            files=upload_file,
-                            data=UPLOAD_BODY)
+                            files=upload_file)
 
     response2 = client.post(f"{HOST_URL}/save_file",
                             headers=token_getter.get_headers(),
-                            files=upload_file,
-                            data=UPLOAD_BODY)
+                            files=upload_file)
 
     assert response1.status_code == 201
     assert str(response1.text).startswith('{"success":"File saved successfully')
@@ -371,8 +373,7 @@ def test_post_file_with_virus_is_blocked():
     upload_virus_file = virus_file.get_data()
     response = client.post(f"{HOST_URL}/save_file",
                            headers=token_getter.get_headers(),
-                           files=upload_virus_file,
-                           data=UPLOAD_BODY)
+                           files=upload_virus_file)
     assert response.status_code == 400
     assert response.json()["detail"] == "Virus Found"
 
@@ -382,27 +383,14 @@ def test_post_file_with_disallowed_file_type_is_blocked():
     upload_disallowed_file = disallowed_file.get_data()
     response = client.post(f"{HOST_URL}/save_file",
                            headers=token_getter.get_headers(),
-                           files=upload_disallowed_file,
-                           data=UPLOAD_BODY)
+                           files=upload_disallowed_file)
     assert response.status_code == 415
     assert response.json()["detail"] == [[415, "File mimetype not allowed"]]
 
 
 @pytest.mark.e2e
-def test_post_file_with_missing_bucket_is_blocked():
-    new_filename = make_unique_name("post_new_file_test.txt")
-    upload_file = test_md_file.get_data(new_filename)
-    # Care with formatting the below - value needs to be str, delimted with '
-    # (Although this is just creating a body that lacks bucketName)
-    data = {"body": '{"folder": "testmult"}'}
-    response = client.post(f"{HOST_URL}/save_file", headers=token_getter.get_headers(), files=upload_file, data=data)
-    assert response.status_code == 400
-    assert response.json()["detail"]["bucketName"] == "Field required"
-
-
-@pytest.mark.e2e
 def test_post_file_without_file_fails_as_expected():
-    response = client.post(f"{HOST_URL}/save_file", headers=token_getter.get_headers(), data=UPLOAD_BODY)
+    response = client.post(f"{HOST_URL}/save_file", headers=token_getter.get_headers())
     assert response.status_code == 400
     assert response.json()["detail"] == "File is required"
 

--- a/tests/routers/test_bulk_upload.py
+++ b/tests/routers/test_bulk_upload.py
@@ -26,9 +26,8 @@ def test_bulk_upload_with_one_file(mock_handler, test_client):
         False
         )
 
-    data = {"body": '{"bucketName": "test_bucket"}'}
     files = [("files", ("test_file.txt", BytesIO(b"Test content"), "text/plain"))]
-    response = test_client.put("/bulk_upload",  data=data, files=files)
+    response = test_client.put("/bulk_upload", files=files)
 
     assert response.status_code == 200
     assert response.json() == {'test_file.txt': {'filename': 'test_file.txt',
@@ -40,7 +39,6 @@ def test_bulk_upload_with_one_file(mock_handler, test_client):
 @patch("src.routers.bulk_upload.handle_file_upload_logic")
 def test_bulk_upload_with_same_filename_thrice(mock_handler, test_client):
     # Upload details
-    data = {"body": '{"bucketName": "test_bucket"}'}
     files = [make_file_tuple("test.txt", b"file1"),
              make_file_tuple("test.txt", b"file2"),
              make_file_tuple("test.txt", b"file3")]
@@ -61,7 +59,7 @@ def test_bulk_upload_with_same_filename_thrice(mock_handler, test_client):
                                     "checksum": "fakechecksum3"  # Expect value from last file
                                     }}
     # Make request
-    response = test_client.put("/bulk_upload",  data=data, files=files)
+    response = test_client.put("/bulk_upload", files=files)
 
     assert response.status_code == 200
     assert response.json() == expected_result
@@ -71,8 +69,6 @@ def test_bulk_upload_with_same_filename_thrice(mock_handler, test_client):
 @pytest.mark.parametrize("file_count", [1, 10, 100, 1000])
 @patch("src.routers.bulk_upload.handle_file_upload_logic")
 def test_bulk_upload_with_multiple_files(mock_handler, file_count, test_client):
-    data = {"body": '{"bucketName": "test_bucket"}'}
-
     # Make files payload
     filenames = [f"file{n}.txt" for n in range(file_count)]
     # f.encode() is simple way of making unique bytes content for each file
@@ -94,7 +90,7 @@ def test_bulk_upload_with_multiple_files(mock_handler, file_count, test_client):
     mock_handler.side_effect = side_effect
 
     # Make request
-    response = test_client.put("/bulk_upload",  data=data, files=files)
+    response = test_client.put("/bulk_upload", files=files)
 
     assert response.status_code == 200
     assert response.json() == expected_result
@@ -104,7 +100,6 @@ def test_bulk_upload_with_multiple_files(mock_handler, file_count, test_client):
 @patch("src.routers.bulk_upload.handle_file_upload_logic")
 def test_bulk_upload_with_both_repeated_and_different_filenames(mock_handler, test_client):
     # Upload details - unique filenames start "u", repeated start "r"
-    data = {"body": '{"bucketName": "test_bucket"}'}
     files = [make_file_tuple("ufile1.txt", b"file1"),
              make_file_tuple("ufile2.txt", b"file2"),
              make_file_tuple("ufile3.txt", b"file3"),
@@ -139,30 +134,86 @@ def test_bulk_upload_with_both_repeated_and_different_filenames(mock_handler, te
     expected_result["ufile4.txt"] = make_file_result("ufile4.txt", [4], [saved_outcome], "fakechecksum5")
 
     # Make request
-    response = test_client.put("/bulk_upload",  data=data, files=files)
+    response = test_client.put("/bulk_upload", files=files)
 
     assert response.status_code == 200
     assert response.json() == expected_result
 
 
-# ====================== FAILURE (general) ====================== #
+# ================== Request Body (data param) ================== #
+"""
+In earlier version of API it was necessary to specify a `bucketName` value
+in the request body but his is no longer the case. Body is now optional and
+only used to specify optional folder value.
+(When making request body is specified using data parameter)
+"""
 
-# "three body problem!" - the 3 tests below have similar data param issues but distinct responses
+
 @patch("src.routers.bulk_upload.handle_file_upload_logic")
-def test_bulk_upload_gives_expected_error_when_data_empty(mock_handler, test_client):
-    data = {}
+def test_bulk_upload_with_no_body_processed_successfully(mock_handler, test_client):
+    mock_handler.return_value = (
+        {"success": "File saved successfully in test_bucket with key test_file.txt",
+         "checksum": "fakechecksum123"},
+        False
+        )
+
     files = [("files", ("test_file.txt", BytesIO(b"Test content"), "text/plain"))]
+    response = test_client.put("/bulk_upload", files=files)
 
-    response = test_client.post("/save_file", data=data, files=files)
-
-    assert response.status_code == 422
-    assert response.json() == {'detail': [{'input': None,
-                                           'loc': ['body', 'body'],
-                                           'msg': 'Field required',
-                                           'type': 'missing'}]}
-    mock_handler.assert_not_called()
+    assert response.status_code == 200
+    assert response.json() == {'test_file.txt': {'filename': 'test_file.txt',
+                                                 'positions': [0],
+                                                 'outcomes': [{'status_code': 201, 'detail': 'saved'}],
+                                                 'checksum': 'fakechecksum123'}}
 
 
+@patch("src.routers.bulk_upload.handle_file_upload_logic")
+def test_bulk_upload_with_body_folder_value_processed_successfully(mock_handler, test_client):
+    # Due to mocked return value we can't see if specified folder has been used from response
+    # but can assert if folder included in FileUpload object passed to  mock handler.
+    mock_handler.return_value = (
+        {"success": "File saved successfully in test_bucket with key test_file.txt",
+         "checksum": "fakechecksum123"},
+        False
+        )
+
+    data = {"body": '{"folder": "test_folder"}'}
+
+    files = [("files", ("test_file.txt", BytesIO(b"Test content"), "text/plain"))]
+    response = test_client.put("/bulk_upload", data=data, files=files)
+
+    assert response.status_code == 200
+    assert response.json() == {'test_file.txt': {'filename': 'test_file.txt',
+                                                 'positions': [0],
+                                                 'outcomes': [{'status_code': 201, 'detail': 'saved'}],
+                                                 'checksum': 'fakechecksum123'}}
+    # Check that the folder specified in request body has been forwarded to file handler in FileUpload object
+    # Note will likley need updating if FileUpload model has new attributes
+    assert "FileUpload(folder='test_folder')" in str(mock_handler.call_args)
+
+
+# Body has syntactically correct json but data is irrelevant - success result
+@patch("src.routers.bulk_upload.handle_file_upload_logic")
+def test_bulk_upload_with_body_with_irrelevant_body_content_processed_successfully(mock_handler, test_client):
+    mock_handler.return_value = (
+        {"success": "File saved successfully in test_bucket with key test_file.txt",
+         "checksum": "fakechecksum123"},
+        False
+        )
+    # Details below are not relevant as they do not correspond with FileUpload model
+    data = {"body": '{"bucketName": "test_bucket", "speed": "extra fast"}'}
+
+    files = [("files", ("test_file.txt", BytesIO(b"Test content"), "text/plain"))]
+    response = test_client.put("/bulk_upload", data=data, files=files)
+
+    assert response.status_code == 200
+    assert response.json() == {'test_file.txt': {'filename': 'test_file.txt',
+                                                 'positions': [0],
+                                                 'outcomes': [{'status_code': 201, 'detail': 'saved'}],
+                                                 'checksum': 'fakechecksum123'}}
+
+
+# Body contains invalid json - fail result
 @patch("src.routers.bulk_upload.handle_file_upload_logic")
 def test_bulk_upload_gives_expected_error_when_body_not_valid(mock_handler, test_client):
     data = {"body": "bad body"}
@@ -175,24 +226,13 @@ def test_bulk_upload_gives_expected_error_when_body_not_valid(mock_handler, test
     mock_handler.assert_not_called()
 
 
-@patch("src.routers.bulk_upload.handle_file_upload_logic")
-def test_bulk_upload_gives_expected_error_when_body_lacks_bucket(mock_handler, test_client):
-    data = {"body": "{}"}
-    files = [("files", ("test_file.txt", BytesIO(b"Test content"), "text/plain"))]
-
-    response = test_client.put("/bulk_upload",  data=data, files=files)
-
-    assert response.status_code == 400
-    assert response.json() == {"detail": {"bucketName": "Field required"}}
-    mock_handler.assert_not_called()
-
+# ====================== FAILURE (general) ====================== #
 
 @patch("src.routers.bulk_upload.handle_file_upload_logic")
 def test_bulk_upload_gives_expected_error_when_no_files(mock_handler, test_client):
-    data = {"body": '{"bucketName": "test_bucket"}'}
     files = []
 
-    response = test_client.put("/bulk_upload",  data=data, files=files)
+    response = test_client.put("/bulk_upload", files=files)
 
     assert response.status_code == 422
     assert response.json() == {"detail": [{"type": "missing",
@@ -206,7 +246,6 @@ def test_bulk_upload_gives_expected_error_when_no_files(mock_handler, test_clien
 
 @patch("src.routers.bulk_upload.handle_file_upload_logic")
 def test_bulk_upload_gives_expected_errors_when_invalid_files_present(mock_handler, test_client):
-    data = {"body": '{"bucketName": "test_bucket"}'}
     # Make files payload
     files = [make_file_tuple("goodfile1.txt", b"file1"),  # Good file
              make_file_tuple("virusfile.txt", b"file2"),  # Bad file
@@ -236,6 +275,6 @@ def test_bulk_upload_gives_expected_errors_when_invalid_files_present(mock_handl
                                                         [{"status_code": 201, "detail": "saved"}],
                                                         "fakechecksum2")
 
-    response = test_client.put("/bulk_upload",  data=data, files=files)
+    response = test_client.put("/bulk_upload", files=files)
     assert response.status_code == 200
     assert response.json() == expected_result

--- a/tests/routers/test_bulk_upload.py
+++ b/tests/routers/test_bulk_upload.py
@@ -143,7 +143,7 @@ def test_bulk_upload_with_both_repeated_and_different_filenames(mock_handler, te
 # ================== Request Body (data param) ================== #
 """
 In earlier version of API it was necessary to specify a `bucketName` value
-in the request body but his is no longer the case. Body is now optional and
+in the request body but this is no longer the case. Body is now optional and
 only used to specify optional folder value.
 (When making request body is specified using data parameter)
 """

--- a/tests/routers/test_save_file.py
+++ b/tests/routers/test_save_file.py
@@ -1,7 +1,7 @@
 from unittest.mock import patch
 from fastapi import HTTPException
 from io import BytesIO
-
+# test_client fixture is defined in tests/fixtures/auth.py
 
 # =========================== SUCCESS =========================== #
 
@@ -13,14 +13,11 @@ def test_save_or_update_file_new_file(handler_mock, test_client):
         False
     )
 
-    data = {
-        "body": '{"bucketName": "test_bucket"}'
-    }
     files = {
         "file": ("test_file.txt", BytesIO(b"Test content"), "text/plain")
     }
 
-    response = test_client.put("/save_or_update_file", data=data, files=files)
+    response = test_client.put("/save_or_update_file", files=files)
 
     assert response.status_code == 201
     assert response.json() == {"success": "File saved successfully in test_bucket with key test_file.txt"}
@@ -35,19 +32,83 @@ def test_save_or_update_file_update_existing(handler_mock, test_client):
         True
     )
 
-    data = {
-        "body": '{"bucketName": "test_bucket"}'
-    }
     files = {
         "file": ("test_file.txt", BytesIO(b"Test content"), "text/plain")
     }
 
-    response = test_client.put("/save_or_update_file", data=data, files=files)
+    response = test_client.put("/save_or_update_file", files=files)
 
     assert response.status_code == 200
     assert response.json() == {"success": "File saved successfully in test_bucket with key test_file.txt"}
 
     handler_mock.assert_called_once()
+
+
+@patch("src.routers.save_or_update_file.handle_file_upload_logic")
+def test_save_or_update_file_with_empty_body_processed_successfully(handler_mock, test_client):
+
+    handler_mock.return_value = (
+        {"success": "File saved successfully in test_bucket with key test_file.txt"},
+        False
+    )
+
+    data = {
+        "body": '{}'
+    }
+
+    files = {
+        'file': ('test_file.txt', BytesIO(b'Test data'), 'text/plain')
+    }
+
+    response = test_client.put('/save_or_update_file', data=data, files=files)
+
+    assert response.status_code == 201
+    assert response.json() == {"success": "File saved successfully in test_bucket with key test_file.txt"}
+
+
+# Body has syntactically correct json but data is irrelevant - success result
+@patch("src.routers.save_or_update_file.handle_file_upload_logic")
+def test_save_or_update_file_with_irrelevant_body_processed_successfully(handler_mock, test_client):
+
+    handler_mock.return_value = (
+        {"success": "File saved successfully in test_bucket with key test_file.txt"},
+        False
+    )
+
+    # Details below are not relevant as they do not correspond with FileUpload model
+    data = {"body": '{"bucketName": "test_bucket", "speed": "extra slow"}'}
+
+    files = {
+        'file': ('test_file.txt', BytesIO(b'Test data'), 'text/plain')
+    }
+
+    response = test_client.put('/save_or_update_file', data=data, files=files)
+
+    assert response.status_code == 201
+    assert response.json() == {"success": "File saved successfully in test_bucket with key test_file.txt"}
+
+
+@patch("src.routers.save_or_update_file.handle_file_upload_logic")
+def test_save_or_update_file_with_body_folder_value_processed_successfully(handler_mock, test_client):
+
+    handler_mock.return_value = (
+        {"success": "File saved successfully in test_bucket with key test_file.txt"},
+        False
+    )
+
+    data = {"body": '{"folder": "another_test_folder"}'}
+
+    files = {
+        'file': ('test_file.txt', BytesIO(b'Test data'), 'text/plain')
+    }
+
+    response = test_client.put('/save_or_update_file', data=data, files=files)
+
+    assert response.status_code == 201
+    assert response.json() == {"success": "File saved successfully in test_bucket with key test_file.txt"}
+    # Check that the folder specified in request body has been forwarded to file handler in FileUpload object
+    # Note will likley need updating if FileUpload model has new attributes
+    assert "FileUpload(folder='another_test_folder')" in str(handler_mock.call_args)
 
 
 # =========================== FAILURE =========================== #
@@ -98,21 +159,4 @@ def test_save_or_update_file_with_invalid_data(test_client):
     response = test_client.put("/save_or_update_file", data=data, files=files)
 
     assert response.status_code == 400
-    content = response.content
-    print(content)
-
-
-# No patch because body validation takes place early in router before handler called
-def test_save_or_update_file_with_missing_bucket_name(test_client):
-    data = {
-        "body": '{}'  # Missing required field 'bucketName'
-    }
-
-    files = {
-        'file': ('test_file.txt', BytesIO(b'Test data'), 'text/plain')
-    }
-
-    response = test_client.put('/save_or_update_file', data=data, files=files)
-
-    assert response.status_code == 400
-    assert response.json() == {"detail": {"bucketName": "Field required"}}
+    assert "Invalid JSON" in response.text

--- a/tests/routers/test_upload_file.py
+++ b/tests/routers/test_upload_file.py
@@ -28,6 +28,68 @@ def test_save_file_success(handler_mock, test_client):
     handler_mock.assert_called_once()
 
 
+@patch("src.routers.save_file.handle_file_upload_logic")
+def test_save_file_with_empty_body_processed_successfully(handler_mock, test_client):
+    handler_mock.return_value = (
+        {"success": "File saved successfully in test_bucket with key test_file.txt"},
+        False
+    )
+
+    data = {
+        "body": "{}"
+    }
+
+    files = {
+        "file": ("test_file.txt", BytesIO(b"Test content"), "text/plain")
+    }
+
+    response = test_client.post("/save_file", data=data, files=files)
+
+    assert response.status_code == 201
+    assert response.json() == {"success": "File saved successfully in test_bucket with key test_file.txt"}
+
+
+@patch("src.routers.save_file.handle_file_upload_logic")
+def test_save_file_with_with_irrelevant_body_processed_successfully(handler_mock, test_client):
+    handler_mock.return_value = (
+        {"success": "File saved successfully in test_bucket with key test_file.txt"},
+        False
+    )
+
+    # Details below are not relevant as they do not correspond with FileUpload model
+    data = {"body": '{"bucketName": "test_bucket", "speed": "extra medium"}'}
+
+    files = {
+        "file": ("test_file.txt", BytesIO(b"Test content"), "text/plain")
+    }
+
+    response = test_client.post("/save_file", data=data, files=files)
+
+    assert response.status_code == 201
+    assert response.json() == {"success": "File saved successfully in test_bucket with key test_file.txt"}
+
+
+@patch("src.routers.save_file.handle_file_upload_logic")
+def test_save_file_with_with_body_folder_value_processed_successfully(handler_mock, test_client):
+    handler_mock.return_value = (
+        {"success": "File saved successfully in test_bucket with key test_file.txt"},
+        False
+    )
+
+    data = {"body": '{"folder": "yet_another_test_folder"}'}
+
+    files = {
+        "file": ("test_file.txt", BytesIO(b"Test content"), "text/plain")
+    }
+
+    response = test_client.post("/save_file", data=data, files=files)
+
+    assert response.status_code == 201
+    assert response.json() == {"success": "File saved successfully in test_bucket with key test_file.txt"}
+    # Check that the folder specified in request body has been forwarded to file handler in FileUpload object
+    # Note will likley need updating if FileUpload model has new attributes
+    assert "FileUpload(folder='yet_another_test_folder')" in str(handler_mock.call_args)
+
 # =========================== FAILURE =========================== #
 
 
@@ -83,23 +145,6 @@ def test_save_file_invalid_data(handler_mock, test_client):
     assert response.status_code == 400
 
     handler_mock.assert_not_called()  # bad JSON fails before calling handler
-
-
-@patch("src.routers.save_file.handle_file_upload_logic")
-def test_save_file_missing_bucket_name(handler_mock, test_client):
-    data = {
-        "body": "{}"
-    }
-    files = {
-        "file": ("test_file.txt", BytesIO(b"Test content"), "text/plain")
-    }
-
-    response = test_client.post("/save_file", data=data, files=files)
-
-    assert response.status_code == 400
-    assert response.content == b'{"detail":{"bucketName":"Field required"}}'
-
-    handler_mock.assert_not_called()  # validation error
 
 
 @patch("src.routers.save_file.handle_file_upload_logic")


### PR DESCRIPTION
## Description of change

**Before Change**
When a file is uploaded by any of our file-upload endpoints (`bulk_upload`, `save_file`, `save_or_update_file`) it is mandatory for the client to include a `bucketName` value in the request body. However, we don't actually use the supplied `bucketName` to select a bucket (we use value from client config instead). The only thing we do with `bucketName` is create a log message if its value is not the same as the bucket name specified in client config.

Note the request body is also used by these endpoints as a source of an optional `folder` value, used to specify a destination S3 folder.

**After Change**
When clients use `bulk_upload`, `save_file` or  `save_or_update_file` endpoints:
- It is no longer necessary for to include `bucketName` in the request body.
- It is also no longer necessary to specify a request body at all.
- The optional `folder` value can still be included in the request body to specify a destination folder
- (not really a change) Superfluous/irrelevant values in the request body are simply ignored without causing problems, so clients can continue to include `bucketName` which just has no effect. 

### Body trouble with defaults and json validation (really model validation)
Removing the need for bucket name was straightforward in itself. However, getting optional body/folder values to work was troublesome, as getting default values to work effectively is fiddly and has pitfalls.

Reading `FileUpload` relies on FastAPI  using `Depends` to apply function returned by `validate_json` to the request body. This is used to both validate and create a FileUpload object from the body. However, this needed changing to suit our new situation in which the request body is used needed for an optional folder value. 
 
Unhelpfully, even when `FileUpload` only has a single optional attribute `folder`, if a request is submitted with no body, our `validate_json` function  rejects it with error message `{"detail":[{"type":"missing","loc":["body","body"],"msg":"Field required","input":null}]}`

With a fair bit of trial and error I've found a way that works that's in new `validate_optional_body_json` function. To get default to work it's necessary to create a `Form` object with a specified default string, `def wrapper(body: str = Form(default='{"body": "{}"}')):`

[One side note, seems that because we're uploading a file we are prevented from using body data in a simple json format [Link](https://stackoverflow.com/a/71439821/17865804) which means some examples of dealing with defaults don't work with these endpoints.]

#### `FileUpload` Model
We had been recording the bucket name in mandatory attribute `FileUpload.bucketName` . This has now been removed.

This leaves `FileUpload` with just an optional `folder` attribute. Note we use `folder` when saving files, so this optional value needs to be retained. 

#### Body handling in  file upload routers
There are three routers that upload files: `bulk_upload`, `save_file`, `save_or_update_file`. All three used to retrieve  `FileUpload` from the request body via function `validate_json` which not only did validation but also extracted relevant data from the body to a `FileUpload` object

These three routers have now been updated to use new function `validate_optional_body_json` which is similar to `validate_json` but no longer requires any expected body data, and will default to an empty body if not present in the request. This means the following three scenarios are now all acceptable:
- no body at all supplied
- body included but without any relevant FileUpload data, e.g. the old `bucketName` value. Any superfluous data is ignored. (Only extract items specified in FileUpload model)
- body has `folder` value. This is extracted and used when writing file to S3.

#### `file_upload_handler` change
`file_upload_handler`  used to log a warning if the supplied bucket name in the request did not match the bucket name from client config. (But also did not use the supplied bucket name for anything else).

I originally updated this to make a log message if a bucket name has been included. However, I found this to be pointless as bucket name now does not reach `file_upload_handler` because the `FileUpload` object received by `file_upload_handler` no longer has a `bucketName` attribute. I've therefore removed any bucket name logging from `file_upload_handler`.

For completeness this function has also been changed to have its own default `body` value but in practice this should not get used as the endpoints that call it all set their own defaults.

### Potential additional changes to "Json validator" functions

- Following these changes, the original `validate_json` function is no longer being used (I think). Potentially it could be removed but we might want to retain it because it provides a generic way of creating a model from a request body, so could be used with future endpoints.
- The main benefit of the functions in `jason_validator.py` is the extraction of data from request body into a particular BaseModel object, with the "validation" just being part of  the model object creation, so classifying them as "validation" might be misleading. It might make sense to rename these functions ( along lines of extract_model_from_body ?) and move them to a different folder such as within the `models` folder. 

## Link to Jira Ticket

- [SDS-261](https://dsdmoj.atlassian.net/browse/SDS-261)

## Screenshots or test evidence if applicable

#### Request with no request body, so not bucket specified, saved successfully
<img width="1436" height="259" alt="image" src="https://github.com/user-attachments/assets/4b7587c4-80a9-402e-9e65-2534c13e995f" />

#### Request with empty body saved as usual
<img width="1451" height="294" alt="image" src="https://github.com/user-attachments/assets/82ff97c6-be77-438c-92e4-70251326a56c" />

#### Request with bucket name saved as usual
<img width="1451" height="289" alt="image" src="https://github.com/user-attachments/assets/81c12c54-b31b-48b9-a40a-0b0725f5b5be" />
(Bucket name has no effect)

#### Request with `folder` in body saves to that folder
<img width="1492" height="290" alt="image" src="https://github.com/user-attachments/assets/25ab5c0d-c4f9-4f3d-ab8e-4d687fa77082" />

Response above indicates folder was used as expected. Also checked in AWS Console that file truly saved in the folder:
<img width="1127" height="428" alt="image" src="https://github.com/user-attachments/assets/b480e323-bc34-4d0b-8788-0783c3f85f5f" />

#### Request with invalid folder specified in body raises relevant error message
<img width="1312" height="290" alt="image" src="https://github.com/user-attachments/assets/12519fa0-ef5d-4a44-83c8-2139aa8b8246" />
Folder value is integer, get response saying folder should be string.

### Postman
I've only done the minimum to get the Postman tests to pass by deleting two obsolete tests that expect an error message when `bucketName` is not present. Potentially more could be done (a) removing unnecessary `bucketName` setting (b) checking for use of `folder` parameter but if we're switching to Bruno maybe leave these until later?

<!-- Any evidence of change working -->

[SDS-261]: https://dsdmoj.atlassian.net/browse/SDS-261?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ