### PR TITLE
Not for production - setting nginx proxy-body-size to see if it affect max upload file size

### DIFF
--- a/deployments/kubernetes/ingress.yml
+++ b/deployments/kubernetes/ingress.yml
@@ -4,6 +4,7 @@ metadata:
   name: laa-sds-ingress
   annotations:
     nginx.ingress.kubernetes.io/whitelist-source-range: 35.178.209.113/32,3.8.51.207/32,35.177.252.54/32,18.169.147.172/32,35.176.93.186/32,18.130.148.126/32,35.176.148.126/32,51.149.250.0/24,51.149.249.0/29,194.33.249.0/29,51.149.249.32/29,194.33.248.0/29,20.49.214.199/32,20.49.214.228/32,20.26.11.71/32,20.26.11.108/32,194.33.200.0/21,194.33.216.0/23,194.33.218.0/24,128.77.75.64/26
+    nginx.ingress.kubernetes.io/proxy-body-size: 100m
     external-dns.alpha.kubernetes.io/set-identifier: laa-sds-ingress-${KUBE_NAMESPACE}-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
 spec:


### PR DESCRIPTION
# >> Experiment - Not for production  <<

## Description of change

Have set `nginx.ingress.kubernetes.io/proxy-body-size: 100m` in `ingress.yml` to see if this sets maximum upload size to 100MB. 

## Link to Jira Ticket


## Screenshots or test evidence if applicable

<!-- Any evidence of change working -->