### PR TITLE
Experiment with putting client config files in S3

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -31,8 +31,12 @@ services:
     environment:
       - DOCKER_HOST=unix:///var/run/docker.sock
     volumes:
+      # Need the configs so .sh script can copy them to the configs S3
+      # Also actual repo name used here not sds-api-configs
+      - ../laa-secure-document-storage-configs/clientconfigs:/clientconfigs
       - ./localstack-script.sh:/etc/localstack/init/ready.d/script.sh
       - '/var/run/docker.sock:/var/run/docker.sock'
+
   laa-clamav:
     image: ghcr.io/ministryofjustice/clamav-docker/laa-clamav:latest
     ports:

--- a/localstack-script.sh/init-local-sds.sh
+++ b/localstack-script.sh/init-local-sds.sh
@@ -9,6 +9,14 @@ awslocal s3api put-bucket-versioning --bucket sds-local --versioning-configurati
 awslocal s3 cp $FILE_TO_UPLOAD s3://sds-local/$FILE_TO_UPLOAD
 awslocal s3 cp $FILE_TO_UPLOAD s3://sds-local/CRM14/$FILE_TO_UPLOAD
 
+# Make config files bucket and copy the config files into it
+# Note:
+# - environmet vars from sds-api section of docker-compose.yml are NOT available here
+# - We're copying from the Localstack container, not locally, so need mapped volume with config files.
+awslocal s3api create-bucket --bucket sds-client-configs --create-bucket-configuration LocationConstraint=eu-west-1
+awslocal s3api put-bucket-versioning --bucket sds-client-configs --versioning-configuration Status=Enabled
+awslocal s3 cp /clientconfigs s3://sds-client-configs/ --recursive
+
 # Initialise audit table - with per-event format
 awslocal --region eu-west-1 dynamodb create-table --table-name $AUDIT_TABLE_NAME \
     --attribute-definitions AttributeName=request_id,AttributeType=S AttributeName=filename_position,AttributeType=N \

--- a/src/routers/health.py
+++ b/src/routers/health.py
@@ -15,6 +15,7 @@ async def health():
     """
     status_report = await status_service.get_status()
     if status_report.has_failures():
+        logger.error(f"Health report has failures: {status_report}")
         raise HTTPException(
             status_code=503,
             detail="Please try again later."

--- a/src/services/client_config_service.py
+++ b/src/services/client_config_service.py
@@ -162,7 +162,7 @@ class ClientConfigService:
         """
         loaded_config = None
         try:
-            s3_client_config_source.polulate_filenames_if_old()
+            s3_client_config_source.populate_filenames_if_old()
             # `/` included in endswith match to avoid picking up multiple users with matching "ends",
             #  e.g. if we have users xyz and wxyz, we don't want xyz also getting wxyz
             candidates: list[str] = [f for f in s3_client_config_source.json_filenames

--- a/src/services/client_config_service.py
+++ b/src/services/client_config_service.py
@@ -10,6 +10,8 @@ import structlog
 
 from src.models.status_report import ServiceObservations, Category
 from src.utils.status_reporter import StatusReporter
+from src.services.s3_client_config_service import s3_client_config_source
+
 
 logger = structlog.get_logger()
 
@@ -144,6 +146,29 @@ class ClientConfigService:
                 logger.error(f"Found {len(candidates)} configs for {self.username} in {os.path.abspath(config_dir)}")
         except Exception as e:
             logger.error(f"Error {e.__class__.__name__} during load of config for '{self.username}': {e}")
+            loaded_config = None
+
+        return loaded_config
+
+    def load_from_s3(self) -> ClientConfig | None:
+        """
+        Attempts to load config from file ending /{username}.json from client-config S3 bucket
+        Created to work in a similar way to existing load_from_file method.
+        """
+        loaded_config = None
+        try:
+            s3_client_config_source.polulate_filenames_if_old()
+            # `/` included in endswith match to avoid picking up multiple users with matching "ends",
+            #  e.g. if we have users xyz and wxyz, we don't want xyz also getting wxyz
+            candidates: list[str] = [f for f in s3_client_config_source.json_filenames
+                                     if f.lower().endswith(f"/{self.username}.json")]
+            if len(candidates) == 1:
+                config_contents: str = s3_client_config_source.get_file(candidates[0])
+                loaded_config = ClientConfig.model_validate_json(config_contents)
+            else:
+                logger.error(f"Found {len(candidates)} configs for {self.username} in client-config S3 bucket")
+        except Exception as e:
+            logger.error(f"Error {e.__class__.__name__} during load of config from S3 for '{self.username}': {e}")
             loaded_config = None
 
         return loaded_config

--- a/src/services/client_config_service.py
+++ b/src/services/client_config_service.py
@@ -81,6 +81,11 @@ class ClientConfigService:
                 and loaded_config is None:
             logger.info(f"Looking for ClientConfig for '{self.username}' from file")
             loaded_config = self.load_from_file()
+            s3_loaded_config = self.load_from_s3()
+            if s3_loaded_config == loaded_config:
+                logger.info(f"Client: {self.username} - loaded config from S3 MATCHES loaded config from file")
+            else:
+                logger.info(f"Client: {self.username} - loaded config from S3 DOESN'T MATCH loaded config from file")
 
         # Only load from environment if other sources are also specified, bit of safety to avoid only trusting the env
         if 'env' in ClientConfigService._config_sources \

--- a/src/services/s3_client_config_service.py
+++ b/src/services/s3_client_config_service.py
@@ -73,9 +73,9 @@ class S3ClientConfigService:
         """
         if not self.last_refresh_time or datetime.datetime.now() - self.last_refresh_time > waitfor:
             self.populate_filenames()
-            logger.info(f"S3 client-config filenames refreshed")
+            logger.info("S3 client-config filenames refreshed")
         else:
-            logger.info(f"S3 client-config filenames not refreshed as last refresh was too recent: {self.last_refresh_time}")
+            logger.info(f"S3 client-config filenames not refreshed as last was too recent: {self.last_refresh_time}")
 
     def populate_filenames(self):
         self.filenames = []

--- a/src/services/s3_client_config_service.py
+++ b/src/services/s3_client_config_service.py
@@ -22,7 +22,7 @@ class S3ClientConfigService:
     not sure what difference this makes - is there a constant connection otherwise? As
     client is presumably sending requests behind the scenes, maybe not?
     """
-    def __init__(self, auto_populate: bool = True):
+    def __init__(self, auto_populate: bool = False):
         self.bucket = os.getenv("CLIENT_CONFIG_BUCKET_NAME", "sds-client-configs")
         self.filenames = []
         self.csv_filenames = []
@@ -79,7 +79,16 @@ class S3ClientConfigService:
 
     def populate_filenames(self):
         self.filenames = []
-        file_details: list[dict] = self.get_details_of_files()
+
+        try:
+            file_details: list[dict] = self.get_details_of_files()
+        except Exception as exc:
+            logger.error(f"Failed to get file details from config file S3: {exc}")
+            # Using [{}] so attempt to get truncation_flag from dict can be made
+            # Alternatively, could just return from here instead which would also
+            # preserve any previously captured details
+            file_details = [{}]
+
         for file_collection in file_details:
             contents = file_collection.get("Contents", [])
             self.filenames.extend([c.get("Key") for c in contents])

--- a/src/services/s3_client_config_service.py
+++ b/src/services/s3_client_config_service.py
@@ -66,7 +66,7 @@ class S3ClientConfigService:
         s3_client.close()
         return all_file_details
 
-    def polulate_filenames_if_old(self, waitfor: datetime.timedelta = datetime.timedelta(hours=1)):
+    def populate_filenames_if_old(self, waitfor: datetime.timedelta = datetime.timedelta(hours=1)):
         """
         Refresh the filenames if either there's no last_refresh_time or the last_refresh_time was
         more than a specified interval in the past (defaults to 1 hour)

--- a/src/services/s3_client_config_service.py
+++ b/src/services/s3_client_config_service.py
@@ -1,0 +1,121 @@
+import os
+import datetime
+import boto3
+import structlog
+
+logger = structlog.get_logger()
+
+
+class S3ClientConfigService:
+    """
+    Gets client config filenames and files from client config S3 bucket.
+    Because these files only change from time-to-time, the details are held within the following
+    attributes:
+        self.filenames - all filenames
+        self.csv_filenames - csv filenames only
+        self.json_filenames - json filenames only
+
+    To refresh these details call the populate_filenames method. This will run automatically
+    when instance created if auto_populate parameter is True.
+
+    Note this only creates a temporary S3 client each time bucket accessed. Could change,
+    not sure what difference this makes - is there a constant connection otherwise? As
+    client is presumably sending requests behind the scenes, maybe not?
+    """
+    def __init__(self, auto_populate: bool = True):
+        self.bucket = os.getenv("CLIENT_CONFIG_BUCKET_NAME", "sds-client-configs")
+        self.filenames = []
+        self.csv_filenames = []
+        self.json_filenames = []
+        self.last_refresh_time: datetime.datetime | None = None
+        if auto_populate:
+            self.populate_filenames()
+
+    def get_s3_client(self):
+        # This duplicates S3Serivce.get_s3_client class method
+        # Could change this to a free-standing function shared by both classes
+        # but keeping separate for now to avoid disruption to existing functionality
+        # (alternatively could go for inheritance-based approach but that might overcomplicate things)
+        s3_client = boto3.client(
+            's3',
+            region_name=os.getenv('AWS_REGION', 'eu-west-2'),
+            aws_access_key_id=os.getenv('AWS_KEY_ID', ''),
+            aws_secret_access_key=os.getenv('AWS_KEY', ''),
+            endpoint_url=os.getenv('AWS_ENDPOINT_URL', 'http://localhost:4566')
+            )
+        return s3_client
+
+    def get_details_of_files(self, max_calls: int = 3, max_keys: int = 1000) -> list[dict]:
+        s3_client = self.get_s3_client()
+        all_file_details = []
+        continuation_token: str | None = None
+        # Need to iterate because there is a maximum number of files that can be returned in one
+        # list_objects_v2 call. Default is 1000 which should be enough, but just in case.
+        for _ in range(max_calls):
+            if not continuation_token:
+                returned_file_details = s3_client.list_objects_v2(Bucket=self.bucket, MaxKeys=max_keys)
+            else:
+                returned_file_details = s3_client.list_objects_v2(Bucket=self.bucket, MaxKeys=max_keys,
+                                                                  ContinuationToken=continuation_token)
+            all_file_details.append(returned_file_details)
+            # Can stop iteration if returned details NOT truncated (so we must have all)
+            if returned_file_details.get("IsTruncated", False) is False:
+                break
+            else:
+                continuation_token = returned_file_details.get("NextContinuationToken")
+        s3_client.close()
+        return all_file_details
+
+    def polulate_filenames_if_old(self, waitfor: datetime.timedelta = datetime.timedelta(hours=1)):
+        """
+        Refresh the filenames if either there's no last_refresh_time or the last_refresh_time was
+        more than a specified interval in the past (defaults to 1 hour)
+        """
+        if not self.last_refresh_time or datetime.datetime.now() - self.last_refresh_time > waitfor:
+            self.populate_filenames()
+            logger.info(f"S3 client-config filenames refreshed")
+        else:
+            logger.info(f"S3 client-config filenames not refreshed as last refresh was too recent: {self.last_refresh_time}")
+
+    def populate_filenames(self):
+        self.filenames = []
+        file_details: list[dict] = self.get_details_of_files()
+        for file_collection in file_details:
+            contents = file_collection.get("Contents", [])
+            self.filenames.extend([c.get("Key") for c in contents])
+        # If final file collection has "IsTruncated" True, then we don't have complete set of details
+        truncation_flag = file_collection.get("IsTruncated", False)
+        if truncation_flag:
+            logger.warning("Config file read from S3 failed to read all the files. Could be too many files.")
+        self.csv_filenames = [f for f in self.filenames if f.lower().endswith(".csv")]
+        self.json_filenames = [f for f in self.filenames if f.lower().endswith(".json")]
+        self.last_refresh_time = datetime.datetime.now()
+
+    def get_file(self, key: str) -> str:
+        """
+        Return specified file content as string. Presumably should be
+        fine as we're only expecting to read csv and json, not binary.
+        """
+        s3_client = self.get_s3_client()
+        # Could change things so we check file is in self.filenames
+        # before atttempting to read it.
+        try:
+            file_object: dict = s3_client.get_object(Bucket=self.bucket, Key=key)
+            file_content = file_object.get("Body").read().decode("utf-8")
+        except Exception as exc:
+            logger.error(f"Failed to read config file {key}: {exc}")
+            file_content = ""
+        finally:
+            s3_client.close()
+        return file_content
+
+    def get_file_lines(self, key: str) -> list[str]:
+        """
+        Return specified file content as list of line-by-line strings.
+        """
+        content = self.get_file(key)
+        return content.splitlines()
+
+
+# Simpler than creating singleton-class? Just create instance that's available for import.
+s3_client_config_source = S3ClientConfigService()

--- a/src/services/s3_service.py
+++ b/src/services/s3_service.py
@@ -4,6 +4,7 @@ from typing import Dict
 import boto3
 import os
 
+
 import structlog
 from botocore.exceptions import ClientError
 
@@ -15,104 +16,6 @@ from src.utils.status_reporter import StatusReporter
 from src.services.checksum_service import hex_string_to_base64_encoded
 
 logger = structlog.get_logger()
-
-
-class S3ClientConfigService:
-    """
-    Gets client config filenames and files from client config S3 bucket.
-    Because these files only change from time-to-time, the details are held within the following
-    attributes:
-        self.filenames - all filenames
-        self.csv_filenames - csv filenames only
-        self.json_filenames - json filenames only
-
-    To refresh these details call the populate_filenames method. This will run automatically
-    when instance created if auto_populate parameter is True.
-
-    Note this only creates a temporary S3 client each time bucket accessed. Could change,
-    not sure what difference this makes - is there a constant connection otherwise? As
-    client is presumably sending requests behind the scenes, maybe not?
-    """
-    def __init__(self, auto_populate: bool = True):
-        self.bucket = os.getenv("CLIENT_CONFIG_BUCKET_NAME", "sds-client-configs")
-        self.filenames = []
-        self.csv_filenames = []
-        self.json_filenames = []
-        if auto_populate:
-            self.populate_filenames()
-
-    def get_s3_client(self):
-        # This duplicates S3Serivce.get_s3_client class method
-        # Could change this to a free-standing function shared by both classes
-        # but keeping separate for now to avoid disruption to existing functionality
-        # (alternatively could go for inheritance-based approach but that might overcomplicate things)
-        s3_client = boto3.client(
-            's3',
-            region_name=os.getenv('AWS_REGION', 'eu-west-2'),
-            aws_access_key_id=os.getenv('AWS_KEY_ID', ''),
-            aws_secret_access_key=os.getenv('AWS_KEY', ''),
-            endpoint_url=os.getenv('AWS_ENDPOINT_URL', 'http://localhost:4566')
-            )
-        return s3_client
-
-    def get_details_of_files(self, max_calls: int = 3, max_keys: int = 1000) -> list[dict]:
-        s3_client = self.get_s3_client()
-        all_file_details = []
-        continuation_token: str | None = None
-        # Need to iterate because there is a maximum number of files that can be returned in one
-        # list_objects_v2 call. Default is 1000 which should be enough, but just in case.
-        for _ in range(max_calls):
-            if not continuation_token:
-                returned_file_details = s3_client.list_objects_v2(Bucket=self.bucket, MaxKeys=max_keys)
-            else:
-                returned_file_details = s3_client.list_objects_v2(Bucket=self.bucket, MaxKeys=max_keys,
-                                                                  ContinuationToken=continuation_token)
-            all_file_details.append(returned_file_details)
-            # Can stop iteration if returned details NOT truncated (so we must have all)
-            if returned_file_details.get("IsTruncated", False) is False:
-                break
-            else:
-                continuation_token = returned_file_details.get("NextContinuationToken")
-        s3_client.close()
-        return all_file_details
-
-    def populate_filenames(self):
-        self.filenames = []
-        file_details: list[dict] = self.get_details_of_files()
-        for file_collection in file_details:
-            contents = file_collection.get("Contents", [])
-            self.filenames.extend([c.get("Key") for c in contents])
-        # If final file collection has "IsTruncated" True, then we don't have complete set of details
-        truncation_flag = file_collection.get("IsTruncated", False)
-        if truncation_flag:
-            logger.warning("Config file read from S3 failed to read all the files. Could be too many files.")
-        self.csv_filenames = [f for f in self.filenames if f.lower().endswith(".csv")]
-        self.json_filenames = [f for f in self.filenames if f.lower().endswith(".json")]
-
-    def get_file(self, key: str) -> str:
-        """
-        Return specified file content as string. Presumably should be
-        fine as we're only expecting to read csv and json, not binary.
-        """
-        s3_client = self.get_s3_client()
-        # Could change things so we check file is in self.filenames
-        # before atttempting to read it.
-        try:
-            file_object: dict = s3_client.get_object(Bucket=self.bucket, Key=key)
-            file_content = file_object.get("Body").read().decode("utf-8")
-        except Exception as exc:
-            logger.error(f"Failed to read config file {key}: {exc}")
-            file_content = ""
-        finally:
-            s3_client.close()
-        return file_content
-
-    def get_file_lines(self, key: str) -> list[str]:
-        """
-        Return specified file content as list of line-by-line strings.
-        """
-        content = self.get_file(key)
-        return content.splitlines()
 
 
 class S3Service:

--- a/src/services/s3_service.py
+++ b/src/services/s3_service.py
@@ -4,7 +4,6 @@ from typing import Dict
 import boto3
 import os
 
-
 import structlog
 from botocore.exceptions import ClientError
 

--- a/src/services/s3_service.py
+++ b/src/services/s3_service.py
@@ -17,6 +17,85 @@ from src.services.checksum_service import hex_string_to_base64_encoded
 logger = structlog.get_logger()
 
 
+class S3ClientConfigService:
+    """
+    Gets client config filenames from client config S3 bucket.
+    Because these files only change from time-to-time, the details are held within the following
+    attributes:
+        self.filenames - all filenames
+        self.csv_filenames - csv filenames only
+        self.json_filenames - json filenames only
+
+    To refresh these details call the populate_filenames method. Note this will run automatically
+    when instance created as long as auto_populate parameter is True.
+
+    Also does not maintain a constant S3 connection. Only creates an S3 client while the
+    file details are being refreshed.  Likely will change once we start to read the files.
+    """
+    def __init__(self, auto_populate: bool = True):
+        self.bucket = os.getenv("CLIENT_CONFIG_BUCKET_NAME", "sds-client-configs")
+        self.filenames = []
+        self.csv_filenames = []
+        self.json_filenames = []
+        if auto_populate:
+            self.populate_filenames()
+
+    def get_s3_client(self):
+        # This duplicates S3Serivce.get_s3_client class method
+        # Could change this to a free-standing function shared by both classes
+        # but keeping separate for now to avoid disruption to existing functionality
+        # (alternatively could go for inheritance-based approach but that might overcomplicate things)
+        s3_client = boto3.client(
+            's3',
+            region_name=os.getenv('AWS_REGION', 'eu-west-2'),
+            aws_access_key_id=os.getenv('AWS_KEY_ID', ''),
+            aws_secret_access_key=os.getenv('AWS_KEY', ''),
+            endpoint_url=os.getenv('AWS_ENDPOINT_URL', 'http://localhost:4566')
+            )
+        return s3_client
+
+    def get_details_of_files(self, max_calls: int = 3, max_keys: int = 1000) -> list[dict]:
+        s3_client = self.get_s3_client()
+        all_file_details = []
+        continuation_token: str | None = None
+        # Need to iterate because there is a maximum number of files that can be returned in one
+        # list_objects_v2 call. Default is 1000 which should be enough, but just in case.
+        for _ in range(max_calls):
+            if not continuation_token:
+                returned_file_details = s3_client.list_objects_v2(Bucket=self.bucket, MaxKeys=max_keys)
+            else:
+                returned_file_details = s3_client.list_objects_v2(Bucket=self.bucket, MaxKeys=max_keys,
+                                                                  ContinuationToken=continuation_token)
+            all_file_details.append(returned_file_details)
+            # Can stop iteration if returned details NOT truncated (so we must have all)
+            if returned_file_details.get("IsTruncated", False) is False:
+                break
+            else:
+                continuation_token = returned_file_details.get("NextContinuationToken")
+        s3_client.close()
+        return all_file_details
+
+    def populate_filenames(self):
+        self.filenames = []
+        file_details: list[dict] = self.get_details_of_files()
+        for file_collection in file_details:
+            contents = file_collection.get("Contents", [])
+            self.filenames.extend([c.get("Key") for c in contents])
+        # If final file collection has "IsTruncated" True, then we don't have complete set of details
+        truncation_flag = file_collection.get("IsTruncated", False)
+        if truncation_flag:
+            logger.warning("Config file read from S3 failed to read all the files. Could be too many files.")
+        self.csv_filenames = [f for f in self.filenames if f.lower().endswith(".csv")]
+        self.json_filenames = [f for f in self.filenames if f.lower().endswith(".json")]
+
+    def get_file(self, key):
+        s3_client = self.get_s3_client()
+        file_object: dict = s3_client.get_object(Bucket=self.bucket, Key=key)
+        print(file_object)
+        s3_client.close()
+        # Update so we return something but need to understand what's in file_object
+
+
 class S3Service:
     _instances: Dict = {}
 

--- a/src/services/s3_service.py
+++ b/src/services/s3_service.py
@@ -19,18 +19,19 @@ logger = structlog.get_logger()
 
 class S3ClientConfigService:
     """
-    Gets client config filenames from client config S3 bucket.
+    Gets client config filenames and files from client config S3 bucket.
     Because these files only change from time-to-time, the details are held within the following
     attributes:
         self.filenames - all filenames
         self.csv_filenames - csv filenames only
         self.json_filenames - json filenames only
 
-    To refresh these details call the populate_filenames method. Note this will run automatically
-    when instance created as long as auto_populate parameter is True.
+    To refresh these details call the populate_filenames method. This will run automatically
+    when instance created if auto_populate parameter is True.
 
-    Also does not maintain a constant S3 connection. Only creates an S3 client while the
-    file details are being refreshed.  Likely will change once we start to read the files.
+    Note this only creates a temporary S3 client each time bucket accessed. Could change,
+    not sure what difference this makes - is there a constant connection otherwise? As
+    client is presumably sending requests behind the scenes, maybe not?
     """
     def __init__(self, auto_populate: bool = True):
         self.bucket = os.getenv("CLIENT_CONFIG_BUCKET_NAME", "sds-client-configs")
@@ -88,12 +89,30 @@ class S3ClientConfigService:
         self.csv_filenames = [f for f in self.filenames if f.lower().endswith(".csv")]
         self.json_filenames = [f for f in self.filenames if f.lower().endswith(".json")]
 
-    def get_file(self, key):
+    def get_file(self, key: str) -> str:
+        """
+        Return specified file content as string. Presumably should be
+        fine as we're only expecting to read csv and json, not binary.
+        """
         s3_client = self.get_s3_client()
-        file_object: dict = s3_client.get_object(Bucket=self.bucket, Key=key)
-        print(file_object)
-        s3_client.close()
-        # Update so we return something but need to understand what's in file_object
+        # Could change things so we check file is in self.filenames
+        # before atttempting to read it.
+        try:
+            file_object: dict = s3_client.get_object(Bucket=self.bucket, Key=key)
+            file_content = file_object.get("Body").read().decode("utf-8")
+        except Exception as exc:
+            logger.error(f"Failed to read config file {key}: {exc}")
+            file_content = ""
+        finally:
+            s3_client.close()
+        return file_content
+
+    def get_file_lines(self, key: str) -> list[str]:
+        """
+        Return specified file content as list of line-by-line strings.
+        """
+        content = self.get_file(key)
+        return content.splitlines()
 
 
 class S3Service:

--- a/src/utils/multifileadapter.py
+++ b/src/utils/multifileadapter.py
@@ -47,9 +47,6 @@ class MultiFileAdapter(casbin.FileAdapter):
 
         # Load policy lines from each of the found file paths
         self.num_files_processed = 0
-        for pi, policy_path in enumerate(policy_file_paths):
-            logger.info(f"> {pi} {policy_path}")
-
         for policy_path in policy_file_paths:
             try:
                 with open(policy_path, "rb") as file:

--- a/src/utils/multifileadapter.py
+++ b/src/utils/multifileadapter.py
@@ -4,6 +4,7 @@ import pathlib
 import casbin
 from casbin import load_policy_line
 import structlog
+from src.services.s3_client_config_service import s3_client_config_source
 
 logger = structlog.get_logger()
 
@@ -18,6 +19,8 @@ class MultiFileAdapter(casbin.FileAdapter):
         self.num_files_processed = 0
         # Do not check if path exists at this entry, because we may have been given a string with colon-separated paths
         self._load_policy_file(model)
+        # New client config load from S3 - in addition to original policy load!
+        self.load_policy_files_from_s3(model)
 
     def _load_policy_file(self, model):
         # List of policy files to be used for loading
@@ -44,6 +47,9 @@ class MultiFileAdapter(casbin.FileAdapter):
 
         # Load policy lines from each of the found file paths
         self.num_files_processed = 0
+        for pi, policy_path in enumerate(policy_file_paths):
+            logger.info(f"> {pi} {policy_path}")
+
         for policy_path in policy_file_paths:
             try:
                 with open(policy_path, "rb") as file:
@@ -55,3 +61,21 @@ class MultiFileAdapter(casbin.FileAdapter):
             except Exception as e:
                 logger.error(f"Failed to load policy file {policy_path}: {e.__class__.__name__} {e}")
         logger.info(f"Processed {self.num_files_processed} policy files")
+
+    def load_policy_files_from_s3(self, model):
+        # For consistency using self.num_files_processed but wonder if this could just be local
+        # variable instead?
+        self.num_files_processed = 0
+        s3_client_config_source.populate_filenames_if_old()
+        s3_policy_file_paths = s3_client_config_source.csv_filenames
+        for s3_policy_path in s3_policy_file_paths:
+            try:
+                lines = s3_client_config_source.get_file_lines(s3_policy_path)
+                # unlike _load_policy_file, (maybe recklessly) using for loop instead of while
+                for line in lines:
+                    # Unlike file load, no decode method call as data is already str
+                    load_policy_line(line.strip(), model)
+                self.num_files_processed += 1
+            except Exception as e:
+                logger.error(f"Failed to load policy file from S3 {s3_policy_path}: {e.__class__.__name__} {e}")
+        logger.info(f"Processed {self.num_files_processed} policy files from S3")


### PR DESCRIPTION
## Description of change

## This is an experiment not intended for production
Related [confluence document](https://dsdmoj.atlassian.net/wiki/spaces/SDS/pages/6217695340/Investigate+using+S3+as+source+of+client+config+for+SDS)

### New S3 bucket with client-config files
`docker-compose.yml` and related `init-local-sds.sh` updated so that when running locally we have a new `sds-client-configs` bucket with client config files copied into it.

### New S3_client_config_service
`S3_client_config_service.py` that gets config files from a new dedicated S3 bucket.

Original plan was to add this to existing `s3_service` module but instead had to be moved to new file to prevent circular imports because `s3_service` imports `client_config_service` whereas `S3_client_config_service` needs to be imported **by** `client_config_service`!

### Updated client_config_service (consumes json config files)
Idea is to try to only make simple changes here. 

- New `load_from_s3` method added that loads json config files from the new S3 bucket. Deliberately works in a similar way to existing `load_from_file` method.
- Existing `load` method updated to read json files from **both** the current file source and the new S3 bucket. Writes log message to confirm if the data received from both sources matches. _As this is a demonstration, this is a handy way of checking the new S3 load is consistent with the existing file load._

### Updated `MultiFileAdapter` (consumes csv config files)
- new `load_policy_files_from_s3` method added that loads csv config files from S3. Works in similar way to existing `_load_policy_file` method.
- Updated existing `load_policy` method to call `load_policy_files_from_s3` in addition to existing `_load_policy_file` , so we can compare both.


## Link to Jira Ticket

- [SDS-213](https://dsdmoj.atlassian.net/browse/SDS-213)

## Screenshots or test evidence if applicable
Unit tests working fine both locally and in pipeline. Needed to tweak `S3_client_config_service` to handle unavailable S3 connection better for pipeline run to work as this affects `test_auth.py` and `test_authz_service.py`

Pytest end-to-end tests fine locally but `test_healthcheck_returns_expected_response` failed in the pipeline, which seems an odd one to fail! 

Postman tests are also mainly passing in the pipeline except three failures from `SDSHealthAndStatusTests` which also has 503 error and looks to be running first.

From further investigation, the "healthcheck" test is legitimately failing because the updated config load is not working in the pipeline because (a) the load process is not finding the S3 bucket (b) the earlier script that puts files into the bucket isn't working either. One of the things that "healthcheck" does is check for at least one loaded `csv` policy file, so this part fails.

On related note, this issue was not obvious because "healthcheck" doesn't actually log this info, which is why this PR has a modified version of the `/health` router to log this info.

<!-- Any evidence of change working -->

**Some log output demonstrating expected behaviour**
This works locally on Mac but not in pipeline.

json config file load
<img width="1487" height="150" alt="image" src="https://github.com/user-attachments/assets/4913628f-b665-4486-9408-7f6a578df333" />

csv config file load
<img width="1416" height="92" alt="image" src="https://github.com/user-attachments/assets/c5141131-4692-4ef5-a9c4-9ce46a8785e4" />

Note 18 files loaded by the existing mechanism but only 17 from the new S3 load because the script that copies files to the S3 does not include the `/authz/casbin_policy_open_routes.csv` file (the only one not in the client-configs repo).

[SDS-213]: https://dsdmoj.atlassian.net/browse/SDS-213?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ