### PR TITLE
Improve output produced by health check endpoint

### DIFF
--- a/src/models/status_report.py
+++ b/src/models/status_report.py
@@ -84,9 +84,9 @@ class StatusReport(BaseModel):
         details = ''
         for so in self.services:
             if so.has_failures():
-                details += (f" Service: {so.label}")
+                details += f" Service: {so.label}"
                 for co in so.observations:
                     if co.category == Category.failure:
-                        details += (f" Failed check: {co.phenomenon}")
+                        details += f" Failed check: {co.phenomenon}"
                  #   details = details + f'[SERVICE: {so} CAT FAILURES: {co}]\n'
         return details

--- a/src/models/status_report.py
+++ b/src/models/status_report.py
@@ -88,5 +88,4 @@ class StatusReport(BaseModel):
                 for co in so.observations:
                     if co.category == Category.failure:
                         details += f" Failed check: {co.phenomenon}"
-                 #   details = details + f'[SERVICE: {so} CAT FAILURES: {co}]\n'
         return details

--- a/src/models/status_report.py
+++ b/src/models/status_report.py
@@ -70,7 +70,7 @@ class ServiceObservations(BaseModel):
 
 class StatusReport(BaseModel):
     """
-    All the service checks combined into a single status report.
+    All the service checks combined into a single status report. return details
     """
     services: List[ServiceObservations] = Field(default_factory=list)
 
@@ -84,8 +84,8 @@ class StatusReport(BaseModel):
         details = ''
         for so in self.services:
             if so.has_failures():
-                details += f" Service: {so.label}"
+                details += f". {so.label.capitalize()}"
                 for co in so.observations:
                     if co.category == Category.failure:
-                        details += f" Failed check: {co.phenomenon}"
+                        details += f" not {co.phenomenon}"
         return details

--- a/src/models/status_report.py
+++ b/src/models/status_report.py
@@ -79,3 +79,14 @@ class StatusReport(BaseModel):
             if so.has_failures():
                 return True
         return False
+
+    def get_failure_details(self) -> str:
+        details = ''
+        for so in self.services:
+            if so.has_failures():
+                details += (f" Service: {so.label}")
+                for co in so.observations:
+                    if co.category == Category.failure:
+                        details += (f" Failed check: {co.phenomenon}")
+                 #   details = details + f'[SERVICE: {so} CAT FAILURES: {co}]\n'
+        return details

--- a/src/routers/health.py
+++ b/src/routers/health.py
@@ -16,7 +16,7 @@ async def health():
     status_report = await status_service.get_status()
     if status_report.has_failures():
         error_report = status_report.get_failure_details()
-        logger.error(f"health check failure: {error_report}")
+        logger.error(f"Health check failure{error_report}")
         raise HTTPException(
             status_code=503,
             detail="Please try again later."

--- a/src/routers/health.py
+++ b/src/routers/health.py
@@ -15,6 +15,8 @@ async def health():
     """
     status_report = await status_service.get_status()
     if status_report.has_failures():
+        error_report = status_report.get_failure_details()
+        logger.error(f"health check failure: {error_report}")
         raise HTTPException(
             status_code=503,
             detail="Please try again later."


### PR DESCRIPTION
## Description of change

The health router updated so that details of failures in the report are recorded to the log. To reduce clutter, there is no need to record the “success” results. Only "failure" results to be recorded

## Link to Jira Ticket

- [SDS-276](https://dsdmoj.atlassian.net/browse/SDS-276)

## Screenshots or test evidence if applicable

<!-- Any evidence of change working -->

{"event": "health check failure:  Service: audit Failed check: reachable Failed check: responding Service: storage Failed check: reachable Failed check: responding Service: antivirus Failed check: reachable Failed check: responding", "request_id": "b229a89067a24adfa31c449440414cc7", "logger": "src.routers.health", "level": "error", "timestamp": "2026-07-23 10:01.40"}
INFO:     127.0.0.1:49302 - "GET /health HTTP/1.1" 503 Service Unavailable



[SDS-276]: https://dsdmoj.atlassian.net/browse/SDS-276?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ