### PR TITLE
SDS-286 - fix two client config data issues

### DIFF
--- a/src/models/client_config.py
+++ b/src/models/client_config.py
@@ -1,3 +1,4 @@
+from typing import Any
 from pydantic import Field, AliasChoices, BaseModel
 from .file_validator_spec import FileValidatorSpec, FileCollectionValidatorSpec
 
@@ -20,3 +21,19 @@ class ClientConfig(BaseModel):
     )
     # No validation_alias specified as we don't seem to be using them
     file_collection_validators: list[FileCollectionValidatorSpec] = Field(default_factory=list)
+
+    def model_post_init(self, context: Any) -> None:
+        """
+        This is special method that's called automatically after usual __init__ completed.
+        Used here to remove any leading `.` from file extensions used in validation, as
+        our validators don't expect the `.` but it may have been included in the source
+        config file.
+        """
+        target_validators = ("AllowedFileExtensions", "DisallowedFileExtensions")
+        for validator in self.file_validators:
+            if validator.name in target_validators and "extensions" in validator.validator_kwargs:
+                validator.validator_kwargs["extensions"] = fix_extensions(validator.validator_kwargs["extensions"])
+
+
+def fix_extensions(extensions: list[str]):
+    return [e.lstrip(".") for e in extensions]

--- a/src/models/client_config.py
+++ b/src/models/client_config.py
@@ -27,7 +27,8 @@ class ClientConfig(BaseModel):
         This is special method that's called automatically after usual __init__ completed.
         Used here to remove any leading `.` from file extensions used in validation, as
         our validators don't expect the `.` but it may have been included in the source
-        config file.
+        config file. Also the converts extensions to lower-case as the validators expect
+        lower-case values.
         """
         target_validators = ("AllowedFileExtensions", "DisallowedFileExtensions")
         for validator in self.file_validators:
@@ -36,4 +37,4 @@ class ClientConfig(BaseModel):
 
 
 def fix_extensions(extensions: list[str]):
-    return [e.lstrip(".") for e in extensions]
+    return [e.lstrip(".").lower() for e in extensions]

--- a/src/validation/file_validator.py
+++ b/src/validation/file_validator.py
@@ -99,7 +99,8 @@ class AllowedFileExtensions(FileValidator):
             raise InvalidValidatorArgumentsError("AllowedFileExtensions validator requires a list of extensions")
         file_ext = os.path.splitext(file_object.filename)[1].strip('.').lower()
         if file_ext not in extensions:
-            logger.error(f"File extension {file_object.filename} not in allowed extensions {extensions}")
+            logger.error(f"File extension {file_ext} of file {file_object.filename} "
+                         f"not in allowed extensions {extensions}")
             return 415, "File extension not allowed"
         return 200, ""
 
@@ -120,7 +121,8 @@ class DisallowedFileExtensions(FileValidator):
             extensions = []
         file_ext = os.path.splitext(file_object.filename)[1].strip('.').lower()
         if file_ext in extensions:
-            logger.error(f"File extension {file_object.filename} in disallowed extensions {extensions}")
+            logger.error(f"File extension {file_ext} of file {file_object.filename} "
+                         f"in disallowed extensions {extensions}")
             return 415, "File extension not allowed"
         return 200, ""
 

--- a/src/validation/file_validator.py
+++ b/src/validation/file_validator.py
@@ -145,7 +145,7 @@ class DisallowedMimetypes(FileValidator):
         if file_object.content_type is None or file_object.content_type == "":
             logger.error(f"File object did not have a content_type attribute {file_object}")
             return 400, 'File mimetype is required'
-        content_type = file_content_type_fix(file_object.content_type)
+        content_type = get_mimetype(file_object.content_type)
         if content_type in content_types:
             logger.error(f"File mimetype {content_type} in disallowed mimetypes {content_types}")
             return 415, "File mimetype not allowed"
@@ -173,18 +173,20 @@ class AllowedMimetypes(FileValidator):
         if file_object.content_type is None or file_object.content_type == "":
             logger.error(f"File object did not have a content_type attribute {file_object}")
             return 400, 'File mimetype is required'
-        content_type = file_content_type_fix(file_object.content_type)
+        content_type = get_mimetype(file_object.content_type)
         if content_type not in content_types:
             logger.error(f"File mimetype {content_type} not in allowed mimetypes {content_types}")
             return 415, "File mimetype not allowed"
         return 200, ""
 
 
-def file_content_type_fix(content_type: str) -> str:
+def get_mimetype(content_type: str) -> str:
     """
-    When file uploaded using Bruno as client, and maybe other clients too, its content type starts with
-    mimetype (which we want) but can be followed by a `;` then character encoding info, e.g. `text/csv; charset=utf-8`,
-    which we don't want. This function:
+    Extract and return mime type from content_type supplied by FastAPI file object.
+    When file uploaded using Bruno as client, and maybe other clients too, content_type starts with
+    mimetype (which we want) but can be followed by a `;` then character encoding info,
+    e.g. `text/csv; charset=utf-8`, which we don't want.
+    This function:
         - Makes the content type lower-case and trims whitespace
         - Strips out the superfluous part from the `;`
         - Also trims whitespace after above

--- a/src/validation/file_validator.py
+++ b/src/validation/file_validator.py
@@ -145,8 +145,9 @@ class DisallowedMimetypes(FileValidator):
         if file_object.content_type is None or file_object.content_type == "":
             logger.error(f"File object did not have a content_type attribute {file_object}")
             return 400, 'File mimetype is required'
-        if file_object.content_type.lower() in content_types:
-            logger.error(f"File mimetype {file_object.content_type.lower()} in disallowed mimetypes {content_types}")
+        content_type = file_content_type_fix(file_object.content_type)
+        if content_type in content_types:
+            logger.error(f"File mimetype {content_type} in disallowed mimetypes {content_types}")
             return 415, "File mimetype not allowed"
         return 200, ""
 
@@ -172,7 +173,23 @@ class AllowedMimetypes(FileValidator):
         if file_object.content_type is None or file_object.content_type == "":
             logger.error(f"File object did not have a content_type attribute {file_object}")
             return 400, 'File mimetype is required'
-        if file_object.content_type.lower() not in content_types:
-            logger.error(f"File mimetype {file_object.content_type} not in allowed mimetypes {content_types}")
+        content_type = file_content_type_fix(file_object.content_type)
+        if content_type not in content_types:
+            logger.error(f"File mimetype {content_type} not in allowed mimetypes {content_types}")
             return 415, "File mimetype not allowed"
         return 200, ""
+
+
+def file_content_type_fix(content_type: str) -> str:
+    """
+    When file uploaded using Bruno as client, and maybe other clients too, its content type starts with
+    mimetype (which we want) but can be followed by a `;` then character encoding info, e.g. `text/csv; charset=utf-8`,
+    which we don't want. This function:
+        - Makes the content type lower-case and trims whitespace
+        - Strips out the superfluous part from the `;`
+        - Also trims whitespace after above
+    """
+    content_type = content_type.lower().strip()
+    if ";" in content_type:
+        content_type = content_type.split(";")[0].strip()
+    return content_type

--- a/tests/end_to_end/test_e2e.py
+++ b/tests/end_to_end/test_e2e.py
@@ -389,6 +389,29 @@ def test_post_file_with_disallowed_file_type_is_blocked():
 
 
 @pytest.mark.e2e
+def test_post_file_with_disallowed_file_type_with_superfluous_data_is_blocked():
+    "Check mime type validation still works when invalid mimetype has charset details appended"
+    file_data = make_file_details(b"Should be blocked", "badfile.txt", "application/x-sh; charset=utf8")
+    response = client.post(f"{HOST_URL}/save_file",
+                           headers=token_getter.get_headers(),
+                           files=file_data)
+    assert response.status_code == 415
+    assert response.json()["detail"] == [[415, "File mimetype not allowed"]]
+
+
+@pytest.mark.e2e
+def test_post_file_with_allowed_file_type_with_superfluous_data_is_allowed():
+    "Check mime type validation still works when valid mimetype has charset details appended"
+    new_filename = make_unique_name("goodfile.txt")
+    file_data = make_file_details(b"Should be allowed", new_filename, "text/xml; charset=utf8")
+    response = client.post(f"{HOST_URL}/save_file",
+                           headers=token_getter.get_headers(),
+                           files=file_data)
+    assert response.status_code == 201
+    assert f"File saved successfully in sds-local with key {new_filename}" in response.text
+
+
+@pytest.mark.e2e
 def test_post_file_without_file_fails_as_expected():
     response = client.post(f"{HOST_URL}/save_file", headers=token_getter.get_headers())
     assert response.status_code == 400

--- a/tests/end_to_end/test_e2e_local_auth.py
+++ b/tests/end_to_end/test_e2e_local_auth.py
@@ -159,6 +159,39 @@ def test_bulk_upload_with_different_user_permissions(username, expected_code, ex
     assert success_count == expected_success_count
 
 
+# Upload file - file extension validators with/without initial `.`
+def test_save_file_blocked_due_to_file_extension_specified_with_dot():
+    """
+    Using all-endpoint-local-dotty-test-user which has config file with
+    disallowed file extensions: .bad and .evil (with dots)
+    File should be blocked because it has .bad extension
+    """
+    newfilename = make_unique_name("oh_no_its.bad")
+    upload_file = make_file_details(b"borogoves", newfilename, "text/plain")
+    response = client.post(f"{HOST_URL}/save_file",
+                           headers={"test-username": "all-endpoint-local-dotty-test-user"},
+                           files=upload_file,
+                           data={"body": '{"bucketName": "sds-local"}'})
+    assert response.status_code == 415
+    assert "File extension not allowed" in response.text
+
+
+def test_save_file_blocked_due_to_file_extension_specified_without_dot():
+    """
+    Using all-endpoint-local-not-dotty-test-user which has config file with
+    disallowed file extensions: bad and evil (without dots)
+    File should be blocked because it has .bad extension
+    """
+    newfilename = make_unique_name("oh_no_its.bad")
+    upload_file = make_file_details(b"borogoves", newfilename, "text/plain")
+    response = client.post(f"{HOST_URL}/save_file",
+                           headers={"test-username": "all-endpoint-local-not-dotty-test-user"},
+                           files=upload_file,
+                           data={"body": '{"bucketName": "sds-local"}'})
+    assert response.status_code == 415
+    assert "File extension not allowed" in response.text
+
+
 # Delete Files
 
 @pytest.mark.e2e

--- a/tests/models/test_client_config_model.py
+++ b/tests/models/test_client_config_model.py
@@ -1,0 +1,59 @@
+import json
+import pytest
+from src.models.client_config import ClientConfig, fix_extensions
+
+"""
+These tests don't cover all aspects of this model.
+Only added to accompany fix to a file extension issue.
+"""
+
+
+# Client config content but with no file validators specified
+base_config = {
+    "azure_client_id": "dummy-abcd-1234-5678",
+    "azure_display_name": "test-config-details",
+    "bucket_name": "sandy",
+    "file_validators": []
+    }
+
+
+@pytest.mark.parametrize("extensions,expected", [([".csv"], ["csv"]),
+                                                 (["csv"], ["csv"]),
+                                                 ([".csv", ".xml"], ["csv", "xml"]),
+                                                 ([".csv", ".xml", "zzz"], ["csv", "xml", "zzz"]),
+                                                 ([".csv", ".abcdefghijk"], ["csv", "abcdefghijk"])
+                                                 ]
+                         )
+def test_fix_extensions(extensions, expected):
+    """Just checking that leading `.` removed from file extensions that have them"""
+    result = fix_extensions(extensions)
+    assert result == expected
+
+
+def test_client_config():
+    # ClientConfig needs json string but easier to construct content
+    # using Python dict, then. use json.dumps
+    config = base_config
+    config["file_validators"].append({"name": "DisallowedFileExtensions",
+                                     "validator_kwargs": {"extensions": [".exe", ".sh", ".bat", "ps"]}
+                                      }
+                                     )
+    config["file_validators"].append({"name": "AllowedFileExtensions",
+                                     "validator_kwargs": {"extensions": [".csv", ".xls", ".xlsx", "tsv"]}
+                                      }
+                                     )
+    # Below is not a genuine validator type - should not be changed
+    config["file_validators"].append({"name": "LostFileExtensions",
+                                      "validator_kwargs": {"extensions": [".abc", ".zzz", "123"]}
+                                      }
+                                     )
+
+    config_json = json.dumps(config)
+    config = ClientConfig.model_validate_json(config_json)
+    # DisallowedFileExtensions (1st) - leading dots removed
+    assert config.file_validators[0].validator_kwargs["extensions"] == ["exe", "sh", "bat", "ps"]
+    # AllowedFileExtensions (2nd) - leading dots removed
+    assert config.file_validators[1].validator_kwargs["extensions"] == ["csv", "xls", "xlsx", "tsv"]
+    # LostFileExtensions (3rd) [not a real one] - no change
+    # This isn't actually a validator type - just demonstrating only the 2 types above are updated
+    assert config.file_validators[2].validator_kwargs["extensions"] == [".abc", ".zzz", "123"]

--- a/tests/models/test_client_config_model.py
+++ b/tests/models/test_client_config_model.py
@@ -21,11 +21,15 @@ base_config = {
                                                  (["csv"], ["csv"]),
                                                  ([".csv", ".xml"], ["csv", "xml"]),
                                                  ([".csv", ".xml", "zzz"], ["csv", "xml", "zzz"]),
-                                                 ([".csv", ".abcdefghijk"], ["csv", "abcdefghijk"])
+                                                 ([".csv", ".abcdefghijk"], ["csv", "abcdefghijk"]),
+                                                 ([".CSV", "CSV"], ["csv", "csv"])
                                                  ]
                          )
 def test_fix_extensions(extensions, expected):
-    """Just checking that leading `.` removed from file extensions that have them"""
+    """
+    Checking that leading `.` removed from file extensions that have them.
+    Also checks conversion to lower-case.
+    """
     result = fix_extensions(extensions)
     assert result == expected
 

--- a/tests/validation_tests/test_client_configured_validator.py
+++ b/tests/validation_tests/test_client_configured_validator.py
@@ -6,6 +6,7 @@ from src.validation.client_configured_validator import get_status_code_for_respo
 from src.validation.file_validator import MaxFileSize, MinFileSize
 from src.validation.file_validator import AllowedFileExtensions, DisallowedFileExtensions
 from src.validation.file_validator import AllowedMimetypes, DisallowedMimetypes
+from src.validation.file_validator import file_content_type_fix
 
 """
 Location of test for functions: validate and get_validator
@@ -215,3 +216,15 @@ def test_get_validator_validate_docstring_with_actual_validator():
 def test_get_status_code_from_response(validator_results, expected_result):
     result = get_status_code_for_response(validator_results)
     assert result == expected_result
+
+
+@pytest.mark.parametrize("original_value,expected", [(";wooo", ""),  # Not expected but for completeness
+                                                     ("keep;begone", "keep"),  # Remove from ;
+                                                     ("  keep ; begone ", "keep"),  # Also whitespace removal
+                                                     ("ABCDE", "abcde"),  # Make lower-case
+                                                     ("text/csv; charset=utf-8", "text/csv"),  # GLAD eg
+                                                     (" Keep ; BEGONE I Say!", "keep")  # Mixture
+                                                     ])
+def test_file_content_type_fix(original_value, expected):
+    result = file_content_type_fix(original_value)
+    assert result == expected

--- a/tests/validation_tests/test_client_configured_validator.py
+++ b/tests/validation_tests/test_client_configured_validator.py
@@ -6,7 +6,7 @@ from src.validation.client_configured_validator import get_status_code_for_respo
 from src.validation.file_validator import MaxFileSize, MinFileSize
 from src.validation.file_validator import AllowedFileExtensions, DisallowedFileExtensions
 from src.validation.file_validator import AllowedMimetypes, DisallowedMimetypes
-from src.validation.file_validator import file_content_type_fix
+from src.validation.file_validator import get_mimetype
 
 """
 Location of test for functions: validate and get_validator
@@ -225,6 +225,6 @@ def test_get_status_code_from_response(validator_results, expected_result):
                                                      ("text/csv; charset=utf-8", "text/csv"),  # GLAD eg
                                                      (" Keep ; BEGONE I Say!", "keep")  # Mixture
                                                      ])
-def test_file_content_type_fix(original_value, expected):
-    result = file_content_type_fix(original_value)
+def test_get_mimetype(original_value, expected):
+    result = get_mimetype(original_value)
     assert result == expected


### PR DESCRIPTION
## Description of change

GLAD team have reported problems with client config validation concerning both file extensions and mimetypes which looks to be due to two problems with client config data handling.

### 1 - File extension leading-dot issue (config file handling problem)
The GLAD team specified `AllowedFileExtensions` and `DisallowedFileExtensions` in their client-config json file but prefixed each extension with a `.` character, e.g. `.csv`. This caused them problems because our validators don't expect the `.`, so an uploaded file with a `csv` extension was blocked because the validator was using a `.csv` allowed value.

To fix this I've updated our `ClientConfig` model to have a `model_post_init` method, which is a special method that automatically runs after `__init__` has been completed (and leaves base class `__init__` untouched). I've placed code in this automatic method to look for client-config file extension values and remove any leading `.` characters from them. This means the issue is fixed at the point the config files are read.

#### Unit tests for model
We don't usually have unit tests for models but I've added a couple related to the above change.

#### Pytest e2e-tests
Two Pytest e2e tests added. These rely on two new "auth bypass" users (`all-endpoint-local-dotty-test-user` and `all-endpoint-local-not-dotty-test-user`) that both have "disallowed file extensions" set, one with `.bad` and the other with `bad`.

_These need client config changes from https://github.com/ministryofjustice/laa-secure-document-storage-configs/pull/19 to work_


#### Additional change
Small improvement to the wording of an existing log message from file extension validators to report both the supplied filename and supplied file extension (would have helped with original diagnosis of this issue!)

Now looks like this
```
{"event": "File extension bad of file 1785749698.809948_oh_no_its.bad in disallowed extensions ['bad', 'evil']"
```
  
#### Aside, some details of how the json config file load works
The file details are loaded by `client_config_service.ClientConfigService.load_from_file` method
which returns a `ClientConfig` object. The `ClientConfig` object has the validator details in its `file_validators` attribute which holds a list of `FileValidatorSpec` objects. The file extensions values of interest are in `validator_kwargs` dictionary within each `FileValidatorSpec` but only named specs `AllowedFileExtensions` and `DisallowedFileExtensions` currently have `extensions`.

#### Additional Thoughts - things not done!
- Potentially we could add more code to fix other potential problems with client config data but I think we should avoid this as we require all client config files to go through a PR which we should use to address any data issues (although wonder if we could have some sort of automatic config validator to the client configs repo)?
- We could add a log message whenever we remove the `.` from supplied file extension but I've **not** done this, partly because the new code is in a model where we don't usually log messages but also because the activity depends on an agreed config file, so it should not be a noteworthy event.
- The changes all sit within `client_config.py` but function that updates the extensions could be part of `file_validator_spec` instead (maybe as a method) but I like having all the changes in one place, especially as they're concise and can all be viewed on screen within the same file, and first bullet point above recommends not expanding this type of thing. 


### 2 - Mime type issue (client request file data issue)
Our client-config file type validators rely on mime types defined in a standard way, e.g. `text/csv`,  consistent with [mime type definitions](https://mimetype.io/all-types). However, when requests with file attachments are sent using Bruno (and maybe from other clients as well) the supplied content type can be set to have a `;` with character encoding value on the end,  e.g. `text/csv; charset=utf-8`, which causes the file to fail mime type validation because our validator compares this whole string against the expected value without the `; charset=utf-8`.

To fix this have added new function that does the following to file content types extracted from client requests:
- Convert to lower case (individual validators were doing this before but now in one place)
- Strip leading/trailing whitespace (additional change - seems good to be forgiving to these external values)
- If there is a `;` character, only take the text to the left of the first `;` and also trim again for whitespace which could have been before the `;` 

Have **not** added a log message to record when the above happens because if a client is including "charset" value in the content type it's likely routine and we could get a lot of these messages adding noise to the logs! 

Have added a couple of pytest e2e tests with `; charset=utf-8` added as it's fairly easy to add this.

## Link to Jira Ticket

- [SDS-286](https://dsdmoj.atlassian.net/browse/SDS-286)

## Screenshots or test evidence if applicable

<!-- Any evidence of change working -->

### File with `csv` extension blocked when `DisallowedFileExtensions` has `.csv` (with dot)

Locally I've setup client config to block `.csv` files and included the `.` in the config file as below:
```
"file_validators": [
    {
      "name": "DisallowedFileExtensions",
      "validator_kwargs": {
        "extensions": [
          ".csv"
        ]
      }
    },
```
Tried to upload file with filename `small.csv`, which is blocked as expected:
<img width="1229" height="266" alt="image" src="https://github.com/user-attachments/assets/8d313678-cada-4592-8643-b5e23432964d" />

Related SDS log message says
```
2026-08-03 09:28:25,501 Request: 6e664670-3d35-4b40-ad86-273822b7edf3, /save_or_update_file, PUT ---> True
{"event": "File extension csv of file small.csv in disallowed extensions ['csv']", "request_id": "2a37b914e43846eb834ef63ab7699f54", "logger": "src.validation.file_validator", "level": "error", "timestamp": "2026-08-03 08:28.25"}
```
Note the log message includes `disallowed extensions ['csv']`, demonstrating that the initial `.` from the config file has been removed as expected.

### Disallowed mime type when "content type" from request has has extra info on end
`text/x-sh` is a standard disallowed mime type in our standard local SDS config.

Made same type of request as before but also with mimetype that starts `text/x-sh` but has `;` and unwanted stuff on end - `'text/x-sh; charset=ZX81'`.

<img width="1241" height="262" alt="image" src="https://github.com/user-attachments/assets/47af3a37-5c3f-4e95-96b1-ea8d8cbc5e24" />

Get expected `File mimetype not allowed` message (in addition to the file extension one which is still valid)

[SDS-286]: https://dsdmoj.atlassian.net/browse/SDS-286?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ